### PR TITLE
Improve cashback UX and transfer tab options

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -14,6 +14,12 @@ const nextConfig = {
         port: '',
         pathname: '/**',
       },
+      {
+        protocol: 'https',
+        hostname: 'uxwing.com',
+        port: '',
+        pathname: '/**',
+      },
     ],
   },
 };

--- a/src/app/transactions/add/TransactionForm.tsx
+++ b/src/app/transactions/add/TransactionForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { Account, Subcategory, Person } from "./page";
 import { createTransaction } from "../actions";
 import AmountInput from "@/components/forms/AmountInput";
@@ -71,21 +71,30 @@ export default function TransactionForm({ accounts, subcategories, people }: Tra
 
   const getTransactionNature = (sub: Subcategory): string | null => {
     if (!sub.categories) return null;
-    if (Array.isArray(sub.categories) && sub.categories.length > 0) return sub.categories[0].transaction_nature;
-    if (typeof sub.categories === "object" && !Array.isArray(sub.categories))
-      return (sub.categories as any).transaction_nature;
-    return null;
+    if (Array.isArray(sub.categories)) {
+      return sub.categories[0]?.transaction_nature ?? null;
+    }
+    return sub.categories.transaction_nature ?? null;
   };
 
-  const mapToOptions = (item: { id: string; name: string; image_url?: string | null; type?: string | null }) => ({
+  const mapToOptions = (item: {
+    id: string;
+    name: string;
+    image_url?: string | null;
+    type?: string | null;
+    is_group?: boolean | null;
+  }) => ({
     id: item.id,
     name: item.name,
     imageUrl: item.image_url || undefined,
-    type: item.type || undefined,
+    type:
+      item.type ||
+      (typeof item.is_group === "boolean" ? (item.is_group ? "Group" : "Cá nhân") : undefined),
   });
 
   const expenseCategories = subcategories.filter((s) => getTransactionNature(s) === "EX").map(mapToOptions);
   const incomeCategories = subcategories.filter((s) => getTransactionNature(s) === "IN").map(mapToOptions);
+  const transferCategories = subcategories.filter((s) => getTransactionNature(s) === "TR").map(mapToOptions);
   const accountsWithOptions = accounts.map(mapToOptions);
   const peopleWithOptions = people.map(mapToOptions);
 
@@ -198,6 +207,36 @@ export default function TransactionForm({ accounts, subcategories, people }: Tra
               options={incomeCategories}
               required
             />
+          </>
+        )}
+
+        {/* TRANSFER */}
+        {activeTab === "transfer" && (
+          <>
+            <CustomSelect
+              label="Danh mục Chuyển khoản"
+              value={subcategoryId}
+              onChange={setSubcategoryId}
+              options={transferCategories}
+              required
+            />
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              <CustomSelect
+                label="Chuyển từ Tài khoản"
+                value={fromAccountId}
+                onChange={setFromAccountId}
+                options={accountsWithOptions}
+                required
+                defaultTab="Account"
+              />
+              <CustomSelect
+                label="Đến Tài khoản"
+                value={toAccountId}
+                onChange={setToAccountId}
+                options={accountsWithOptions}
+                required
+              />
+            </div>
           </>
         )}
 

--- a/src/app/transactions/add/page.tsx
+++ b/src/app/transactions/add/page.tsx
@@ -11,26 +11,29 @@ export type Account = {
   cashback_percentage: number | null;
   max_cashback_amount: number | null;
 };
-export type Subcategory = { 
-  id: string; 
-  name: string; 
-  image_url: string | null;
-  categories: { 
-    name: string; 
-    transaction_nature: string; 
-  }[] | null 
+type CategoryInfo = {
+  name: string;
+  transaction_nature: string;
 };
-export type Person = { 
-  id: string; 
-  name: string; 
-  image_url: string | null; 
+
+export type Subcategory = {
+  id: string;
+  name: string;
+  image_url: string | null;
+  categories: CategoryInfo[] | CategoryInfo | null;
+};
+export type Person = {
+  id: string;
+  name: string;
+  image_url: string | null;
+  is_group: boolean | null;
 };
 
 async function getFormData() {
   // Lấy thêm các trường cashback từ bảng accounts
   const accountsPromise = supabase.from("accounts").select("id, name, image_url, type, is_cashback_eligible, cashback_percentage, max_cashback_amount");
   const subcategoriesPromise = supabase.from("subcategories").select("id, name, image_url, categories(name, transaction_nature)");
-  const peoplePromise = supabase.from("people").select("id, name, image_url");
+  const peoplePromise = supabase.from("people").select("id, name, image_url, is_group");
 
   const [
     { data: accounts, error: accountsError },

--- a/src/components/forms/CustomSelect.tsx
+++ b/src/components/forms/CustomSelect.tsx
@@ -3,23 +3,48 @@
 import { Listbox, Transition } from '@headlessui/react';
 // SỬA Ở ĐÂY: Import lại component Image
 import Image from 'next/image';
-import { Fragment, useState, useMemo } from 'react';
+import { Fragment, useState, useMemo, useEffect, useRef } from 'react';
 
 export type Option = { id: string; name: string; imageUrl?: string; type?: string; };
-type CustomSelectProps = { label: string; value: string; onChange: (value: string) => void; options: Option[]; required?: boolean; };
+type CustomSelectProps = {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  options: Option[];
+  required?: boolean;
+  defaultTab?: string;
+};
 
 const SelectorIcon = () => <svg className="h-5 w-5 text-gray-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"><path fillRule="evenodd" d="M10 3a1 1 0 01.707.293l3 3a1 1 0 01-1.414 1.414L10 5.414 7.707 7.707a1 1 0 01-1.414-1.414l3-3A1 1 0 0110 3zm-3.707 9.293a1 1 0 011.414 0L10 14.586l2.293-2.293a1 1 0 011.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z" clipRule="evenodd" /></svg>;
 const SearchIcon = () => <svg className="h-5 w-5 text-gray-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"><path fillRule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clipRule="evenodd" /></svg>;
 
-export default function CustomSelect({ label, value, onChange, options, required = false }: CustomSelectProps) {
+export default function CustomSelect({ label, value, onChange, options, required = false, defaultTab }: CustomSelectProps) {
   const [query, setQuery] = useState('');
   const [activeTab, setActiveTab] = useState('All');
+  const appliedDefaultRef = useRef(false);
 
   const accountTypes = useMemo(() => {
     const types = new Set<string>();
     options.forEach(opt => { if (opt.type) { types.add(opt.type); } });
     return ['All', ...Array.from(types)];
   }, [options]);
+
+  useEffect(() => {
+    appliedDefaultRef.current = false;
+  }, [defaultTab]);
+
+  useEffect(() => {
+    if (!defaultTab || appliedDefaultRef.current) return;
+    if (accountTypes.includes(defaultTab)) {
+      setActiveTab(defaultTab);
+      appliedDefaultRef.current = true;
+    }
+  }, [defaultTab, accountTypes]);
+
+  useEffect(() => {
+    if (accountTypes.includes(activeTab)) return;
+    setActiveTab('All');
+  }, [accountTypes, activeTab]);
 
   const filteredOptions = useMemo(() => {
     let filtered = options;
@@ -33,7 +58,10 @@ export default function CustomSelect({ label, value, onChange, options, required
   return (
     <div>
       <Listbox value={value} onChange={onChange}>
-        <Listbox.Label className="block text-sm font-medium text-gray-700">{label}</Listbox.Label>
+        <Listbox.Label className="block text-sm font-medium text-gray-700">
+          {label}
+          {required && <span className="ml-1 text-red-500">*</span>}
+        </Listbox.Label>
         <div className="mt-1 relative">
           <Listbox.Button className="relative w-full bg-white border border-gray-300 rounded-md shadow-sm pl-3 pr-10 py-3 text-left cursor-default focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm">
             <span className="flex items-center">


### PR DESCRIPTION
## Summary
- redesign the cashback input to allow independent percent/amount editing, enforce account limits, and show contextual guidance
- group people options by the is_group flag, add dedicated transfer tab selects, and surface new subcategory/people metadata
- permit Next Image to load avatars from uxwing.com and let select widgets default to a specific tab when requested

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d3bde77de0832981cc01390cd55369