### PR TITLE
feat: internationalize ui and enhance transactions list

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -20,6 +20,12 @@ const nextConfig = {
         port: '',
         pathname: '/**',
       },
+      {
+        protocol: 'https',
+        hostname: 'i.postimg.cc',
+        port: '',
+        pathname: '/**',
+      },
     ],
   },
 };

--- a/src/app/categories/actions.ts
+++ b/src/app/categories/actions.ts
@@ -28,7 +28,7 @@ const normalizeImageUrl = (value?: string | null) => {
 export async function createCategory(input: CreateCategoryInput): Promise<ActionResult> {
   const name = input.name.trim();
   if (!name) {
-    return { success: false, message: "Vui lòng nhập tên danh mục." };
+    return { success: false, message: "Please provide a category name." };
   }
 
   const transactionNature = VALID_NATURES.includes(input.transactionNature)
@@ -48,8 +48,8 @@ export async function createCategory(input: CreateCategoryInput): Promise<Action
     .single();
 
   if (error) {
-    console.error("Không thể tạo danh mục:", error);
-    return { success: false, message: "Không thể tạo danh mục mới." };
+    console.error("Unable to create category:", error);
+    return { success: false, message: "Unable to create a new category." };
   }
 
   revalidatePath("/categories");
@@ -59,7 +59,7 @@ export async function createCategory(input: CreateCategoryInput): Promise<Action
 
   return {
     success: true,
-    message: "Tạo danh mục thành công!",
+    message: "Category created successfully!",
     categoryId: data?.id,
   };
 }

--- a/src/app/categories/add/page.tsx
+++ b/src/app/categories/add/page.tsx
@@ -1,4 +1,5 @@
 import CategoryForm from "@/components/categories/CategoryForm";
+import { createTranslator } from "@/lib/i18n";
 
 const DEFAULT_RETURN_PATH = "/categories";
 
@@ -23,10 +24,11 @@ export default function AddCategoryPage({ searchParams }: AddCategoryPageProps) 
   const params = searchParams ?? {};
   const returnTo = normalizeReturnPath(params.returnTo);
   const defaultNature = typeof params.defaultNature === "string" ? params.defaultNature : undefined;
+  const t = createTranslator();
 
   return (
     <div>
-      <h1 className="text-3xl font-bold text-gray-800 mb-6">Thêm danh mục mới</h1>
+      <h1 className="text-3xl font-bold text-gray-800 mb-6">{t("categoryForm.title")}</h1>
       <div className="bg-white rounded-lg shadow-md p-6">
         <CategoryForm returnTo={returnTo} defaultNature={defaultNature} />
       </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,10 @@
 import { supabase } from "@/lib/supabaseClient";
 import AccountsTable from "@/components/AccountsTable";
 import StatCard from "@/components/StatCard";
-// SỬA Ở ĐÂY: Không cần import icon ở trang này nữa
+import { createTranslator } from "@/lib/i18n";
 
-// Hàm định dạng tiền tệ
 const formatCurrency = (amount: number) => {
-  return new Intl.NumberFormat('vi-VN', { style: 'currency', currency: 'VND' }).format(amount);
+  return new Intl.NumberFormat("en-US", { style: "currency", currency: "VND" }).format(amount);
 };
 export type Account = {
   id: string;
@@ -28,6 +27,7 @@ type TransactionRecord = {
 };
 
 export default async function Home() {
+  const t = createTranslator();
   const { data: accountsData } = await supabase.from("accounts").select();
   const { data: transactionsData } = await supabase
     .from("transactions")
@@ -66,20 +66,15 @@ export default async function Home() {
 
   return (
     <div>
-      <h1 className="text-3xl font-bold text-gray-800 mb-6">
-        Dashboard
-      </h1>
-      
+      <h1 className="text-3xl font-bold text-gray-800 mb-6">{t("dashboard.title")}</h1>
+
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
-        {/* SỬA Ở ĐÂY: Truyền 'type' thay vì 'icon' */}
-        <StatCard title="Thu nhập Tháng này" value={formatCurrency(totalIncomeThisMonth)} type="income" />
-        <StatCard title="Chi tiêu Tháng này" value={formatCurrency(totalExpenseThisMonth)} type="expense" />
-        <StatCard title="Số dư Hiện tại" value={formatCurrency(netWorth)} type="balance" />
+        <StatCard title={t("dashboard.incomeThisMonth")} value={formatCurrency(totalIncomeThisMonth)} type="income" />
+        <StatCard title={t("dashboard.expenseThisMonth")} value={formatCurrency(totalExpenseThisMonth)} type="expense" />
+        <StatCard title={t("dashboard.currentBalance")} value={formatCurrency(netWorth)} type="balance" />
       </div>
 
-      <h2 className="text-2xl font-bold text-gray-800 mb-4">
-        Tài khoản
-      </h2>
+      <h2 className="text-2xl font-bold text-gray-800 mb-4">{t("dashboard.accountsHeading")}</h2>
       <AccountsTable accounts={accountsData || []} />
     </div>
   );

--- a/src/app/transactions/DeleteButton.tsx
+++ b/src/app/transactions/DeleteButton.tsx
@@ -1,20 +1,22 @@
 "use client";
 
-// SỬA Ở ĐÂY: Dùng đường dẫn tuyệt đối
 import { deleteTransaction } from "@/app/transactions/actions";
+import { createTranslator } from "@/lib/i18n";
 
 type DeleteButtonProps = {
   transactionId: string;
 };
 
 export default function DeleteButton({ transactionId }: DeleteButtonProps) {
+  const t = createTranslator();
+
   const handleDelete = async () => {
-    if (confirm("Bạn có chắc chắn muốn xóa giao dịch này không?")) {
+    if (confirm(t("delete.confirm"))) {
       const result = await deleteTransaction(transactionId);
       if (result.success) {
-        alert("Xóa thành công!");
+        alert(t("delete.success"));
       } else {
-        alert(`Lỗi: ${result.message}`);
+        alert(`${t("delete.error")}: ${result.message}`);
       }
     }
   };
@@ -24,7 +26,7 @@ export default function DeleteButton({ transactionId }: DeleteButtonProps) {
       onClick={handleDelete}
       className="text-red-600 hover:text-red-800 font-medium"
     >
-      Xóa
+      {t("delete.button")}
     </button>
   );
 }

--- a/src/app/transactions/TransactionsView.tsx
+++ b/src/app/transactions/TransactionsView.tsx
@@ -1,0 +1,402 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+import CustomSelect, { Option } from "@/components/forms/CustomSelect";
+import DeleteButton from "./DeleteButton";
+import { createTranslator } from "@/lib/i18n";
+
+import type { AccountRecord, TransactionFilters, TransactionListItem } from "./page";
+
+type TransactionsViewProps = {
+  transactions: TransactionListItem[];
+  totalCount: number;
+  accounts: AccountRecord[];
+  filters: TransactionFilters;
+};
+
+type NatureTab = {
+  value: TransactionFilters["nature"];
+  labelKey: "transactions.tabs.all" | "transactions.tabs.income" | "transactions.tabs.expense" | "transactions.tabs.transfer";
+};
+
+const natureTabs: NatureTab[] = [
+  { value: "all", labelKey: "transactions.tabs.all" },
+  { value: "income", labelKey: "transactions.tabs.income" },
+  { value: "expense", labelKey: "transactions.tabs.expense" },
+  { value: "transfer", labelKey: "transactions.tabs.transfer" },
+];
+
+const PAGE_SIZE_OPTIONS = [10, 25, 50];
+
+const currencyFormatter = new Intl.NumberFormat("en-US", { style: "currency", currency: "VND" });
+const monthFormatter = new Intl.DateTimeFormat("en-US", { month: "long" });
+
+const monthOptions = Array.from({ length: 12 }, (_, index) => ({
+  value: String(index + 1),
+  label: monthFormatter.format(new Date(2000, index, 1)),
+}));
+
+const quarterOptions = [1, 2, 3, 4].map((value) => ({ value: String(value), label: `Q${value}` }));
+
+const formatCurrency = (amount: number) => currencyFormatter.format(amount);
+const formatDate = (date: string) => new Date(date).toLocaleDateString("en-US");
+
+export default function TransactionsView({ transactions, totalCount, accounts, filters }: TransactionsViewProps) {
+  const t = createTranslator();
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set());
+  const [showSelectedOnly, setShowSelectedOnly] = useState(false);
+
+  useEffect(() => {
+    setSelectedIds((prev) => {
+      const currentIds = new Set(transactions.map((tx) => tx.id));
+      const next = new Set<string>();
+      prev.forEach((id) => {
+        if (currentIds.has(id)) {
+          next.add(id);
+        }
+      });
+      return next;
+    });
+  }, [transactions]);
+
+  const accountOptions: Option[] = useMemo(
+    () =>
+      accounts.map((account) => ({
+        id: account.id,
+        name: account.name,
+        imageUrl: account.image_url ?? undefined,
+        type: account.type ?? undefined,
+      })),
+    [accounts]
+  );
+
+  const yearOptions = useMemo(() => {
+    const current = new Date().getFullYear();
+    const maxYear = Math.max(current, filters.year);
+    const years = new Set<number>();
+    for (let offset = 0; offset < 6; offset += 1) {
+      years.add(maxYear - offset);
+    }
+    return Array.from(years).sort((a, b) => b - a);
+  }, [filters.year]);
+
+  const visibleTransactions = showSelectedOnly
+    ? transactions.filter((transaction) => selectedIds.has(transaction.id))
+    : transactions;
+
+  const totalPages = Math.max(1, Math.ceil(totalCount / filters.pageSize));
+  const allVisibleSelected =
+    visibleTransactions.length > 0 && visibleTransactions.every((transaction) => selectedIds.has(transaction.id));
+
+  const updateFilters = (updates: Record<string, string | undefined>, resetPage = true) => {
+    const params = new URLSearchParams(searchParams.toString());
+
+    Object.entries(updates).forEach(([key, value]) => {
+      if (value == null || value === "") {
+        params.delete(key);
+      } else {
+        params.set(key, value);
+      }
+    });
+
+    if (resetPage) {
+      params.set("page", "1");
+    }
+
+    const query = params.toString();
+    router.push(query ? `${pathname}?${query}` : pathname);
+  };
+
+  const handleSelectAll = () => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (allVisibleSelected) {
+        visibleTransactions.forEach((transaction) => next.delete(transaction.id));
+      } else {
+        visibleTransactions.forEach((transaction) => next.add(transaction.id));
+      }
+      return next;
+    });
+  };
+
+  const toggleSelection = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const handlePageChange = (nextPage: number) => {
+    if (nextPage < 1 || nextPage > totalPages) {
+      return;
+    }
+    updateFilters({ page: String(nextPage) }, false);
+  };
+
+  const handleReset = () => {
+    router.push(pathname);
+  };
+
+  const monthValue = filters.month === "all" ? "all" : String(filters.month);
+  const quarterValue = filters.quarter === "all" ? "all" : String(filters.quarter);
+
+  return (
+    <div className="bg-white rounded-lg shadow-md">
+      <div className="border-b px-4 py-4 space-y-4">
+        <div className="flex flex-wrap gap-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="year-filter">
+              {t("transactions.filters.year")}
+            </label>
+            <select
+              id="year-filter"
+              className="rounded-md border-gray-300 py-2 px-3 focus:border-indigo-500 focus:ring-indigo-500"
+              value={filters.year}
+              onChange={(event) => updateFilters({ year: event.target.value })}
+            >
+              {yearOptions.map((year) => (
+                <option key={year} value={year}>
+                  {year}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="month-filter">
+              {t("transactions.filters.month")}
+            </label>
+            <select
+              id="month-filter"
+              className="rounded-md border-gray-300 py-2 px-3 focus:border-indigo-500 focus:ring-indigo-500"
+              value={monthValue}
+              onChange={(event) => updateFilters({ month: event.target.value })}
+            >
+              <option value="all">{t("transactions.tabs.all")}</option>
+              {monthOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="quarter-filter">
+              {t("transactions.filters.quarter")}
+            </label>
+            <select
+              id="quarter-filter"
+              className="rounded-md border-gray-300 py-2 px-3 focus:border-indigo-500 focus:ring-indigo-500"
+              value={quarterValue}
+              onChange={(event) => updateFilters({ quarter: event.target.value })}
+            >
+              <option value="all">{t("transactions.tabs.all")}</option>
+              {quarterOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="min-w-[220px] space-y-2">
+            <CustomSelect
+              label={t("transactions.filters.account")}
+              value={filters.accountId}
+              onChange={(value) => updateFilters({ accountId: value === "__add_new__" ? undefined : value })}
+              options={accountOptions}
+            />
+            {filters.accountId && (
+              <button
+                type="button"
+                onClick={() => updateFilters({ accountId: undefined })}
+                className="text-xs text-indigo-600 hover:text-indigo-800"
+              >
+                {t("transactions.filters.allAccounts")}
+              </button>
+            )}
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="page-size">
+              {t("transactions.filters.pageSize")}
+            </label>
+            <select
+              id="page-size"
+              className="rounded-md border-gray-300 py-2 px-3 focus:border-indigo-500 focus:ring-indigo-500"
+              value={filters.pageSize}
+              onChange={(event) => updateFilters({ pageSize: event.target.value })}
+            >
+              {PAGE_SIZE_OPTIONS.map((size) => (
+                <option key={size} value={size}>
+                  {size}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="self-end">
+            <button
+              type="button"
+              onClick={handleReset}
+              className="rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100"
+            >
+              {t("transactions.filters.reset")}
+            </button>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div className="flex flex-wrap gap-2">
+            {natureTabs.map((tab) => (
+              <button
+                key={tab.value}
+                type="button"
+                onClick={() => updateFilters({ nature: tab.value })}
+                className={`px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+                  filters.nature === tab.value
+                    ? "bg-indigo-600 text-white shadow"
+                    : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+                }`}
+              >
+                {t(tab.labelKey)}
+              </button>
+            ))}
+          </div>
+
+          <label className="flex items-center gap-2 text-sm text-gray-600">
+            <input
+              type="checkbox"
+              className="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+              checked={showSelectedOnly}
+              onChange={(event) => setShowSelectedOnly(event.target.checked)}
+            />
+            {t("transactions.filters.showOnlySelected")}
+          </label>
+        </div>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200 text-sm">
+          <thead>
+            <tr>
+              <th className="px-4 py-3">
+                <div className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    className="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                    aria-label={t("transactions.filters.selectAll")}
+                    checked={allVisibleSelected && visibleTransactions.length > 0}
+                    onChange={handleSelectAll}
+                  />
+                </div>
+              </th>
+              <th className="whitespace-nowrap px-4 py-3 text-left font-medium text-gray-700">
+                {t("transactions.tableHeaders.date")}
+              </th>
+              <th className="whitespace-nowrap px-4 py-3 text-left font-medium text-gray-700">
+                {t("transactions.tableHeaders.category")}
+              </th>
+              <th className="whitespace-nowrap px-4 py-3 text-left font-medium text-gray-700">
+                {t("transactions.tableHeaders.account")}
+              </th>
+              <th className="whitespace-nowrap px-4 py-3 text-left font-medium text-gray-700">
+                {t("transactions.tableHeaders.notes")}
+              </th>
+              <th className="whitespace-nowrap px-4 py-3 text-right font-medium text-gray-700">
+                {t("transactions.tableHeaders.amount")}
+              </th>
+              <th className="whitespace-nowrap px-4 py-3 text-right font-medium text-gray-700">
+                {t("common.actions")}
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200">
+            {visibleTransactions.map((transaction) => {
+              const isSelected = selectedIds.has(transaction.id);
+              const categoryLabel = transaction.categoryName
+                ? transaction.subcategoryName
+                  ? `${transaction.categoryName} / ${transaction.subcategoryName}`
+                  : transaction.categoryName
+                : transaction.subcategoryName ?? "-";
+
+              let accountLabel = "-";
+              if (transaction.fromAccount?.name && transaction.toAccount?.name) {
+                accountLabel = `${transaction.fromAccount.name} -> ${transaction.toAccount.name}`;
+              } else if (transaction.fromAccount?.name || transaction.toAccount?.name) {
+                accountLabel = transaction.fromAccount?.name ?? transaction.toAccount?.name ?? "-";
+              }
+
+              return (
+                <tr key={transaction.id} className={isSelected ? "bg-indigo-50" : undefined}>
+                  <td className="px-4 py-3">
+                    <input
+                      type="checkbox"
+                      className="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                      checked={isSelected}
+                      onChange={() => toggleSelection(transaction.id)}
+                      aria-label={`Select transaction ${transaction.id}`}
+                    />
+                  </td>
+                  <td className="whitespace-nowrap px-4 py-3 text-gray-700">{formatDate(transaction.date)}</td>
+                  <td className="whitespace-nowrap px-4 py-3 text-gray-700">{categoryLabel}</td>
+                  <td className="whitespace-nowrap px-4 py-3 text-gray-700">{accountLabel}</td>
+                  <td className="px-4 py-3 text-gray-500 max-w-xs truncate">{transaction.notes ?? "-"}</td>
+                  <td className="whitespace-nowrap px-4 py-3 text-right font-medium text-gray-800">
+                    {formatCurrency(transaction.amount)}
+                  </td>
+                  <td className="whitespace-nowrap px-4 py-3 text-right">
+                    <DeleteButton transactionId={transaction.id} />
+                  </td>
+                </tr>
+              );
+            })}
+            {visibleTransactions.length === 0 && (
+              <tr>
+                <td className="px-4 py-6 text-center text-gray-500" colSpan={7}>
+                  {t("transactions.emptyState")}
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="flex flex-col gap-3 border-t px-4 py-4 text-sm text-gray-600 md:flex-row md:items-center md:justify-between">
+        <span>
+          {t("transactions.pagination.pageLabel")} {filters.page} {t("transactions.pagination.of")} {totalPages}
+        </span>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => handlePageChange(filters.page - 1)}
+            disabled={filters.page <= 1}
+            className="rounded-md border border-gray-300 px-3 py-2 font-medium text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {t("transactions.pagination.previous")}
+          </button>
+          <button
+            type="button"
+            onClick={() => handlePageChange(filters.page + 1)}
+            disabled={filters.page >= totalPages}
+            className="rounded-md border border-gray-300 px-3 py-2 font-medium text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {t("transactions.pagination.next")}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/transactions/add/page.tsx
+++ b/src/app/transactions/add/page.tsx
@@ -1,11 +1,11 @@
 import { supabase } from "@/lib/supabaseClient";
+import { createTranslator } from "@/lib/i18n";
 import TransactionForm from "./TransactionForm";
 
-// Thêm các trường cashback vào type Account
-export type Account = { 
-  id: string; 
-  name: string; 
-  image_url: string | null; 
+export type Account = {
+  id: string;
+  name: string;
+  image_url: string | null;
   type: string | null;
   is_cashback_eligible: boolean | null;
   cashback_percentage: number | null;
@@ -23,6 +23,13 @@ export type Subcategory = {
   transaction_nature?: string | null;
   categories: CategoryInfo[] | CategoryInfo | null;
 };
+type CategoryRecord = {
+  id: string;
+  name: string;
+  transaction_nature: string;
+  image_url?: string | null;
+};
+
 export type Person = {
   id: string;
   name: string;
@@ -31,38 +38,66 @@ export type Person = {
 };
 
 async function getFormData() {
-  // Lấy thêm các trường cashback từ bảng accounts
   const accountsPromise = supabase.from("accounts").select("id, name, image_url, type, is_cashback_eligible, cashback_percentage, max_cashback_amount");
   const subcategoriesPromise = supabase
     .from("subcategories")
     .select("id, name, image_url, transaction_nature, categories(name, transaction_nature)");
   const peoplePromise = supabase.from("people").select("id, name, image_url, is_group");
+  const categoriesPromise = supabase.from("categories").select("id, name, transaction_nature, image_url");
 
   const [
     { data: accounts, error: accountsError },
     { data: subcategories, error: subcategoriesError },
     { data: people, error: peopleError },
-  ] = await Promise.all([accountsPromise, subcategoriesPromise, peoplePromise]);
+    { data: categories, error: categoriesError },
+  ] = await Promise.all([accountsPromise, subcategoriesPromise, peoplePromise, categoriesPromise]);
 
-  if (accountsError || subcategoriesError || peopleError) {
-    console.error("Error fetching form data:", { accountsError, subcategoriesError, peopleError });
+  if (accountsError) {
+    console.error("Failed to fetch accounts:", accountsError);
+  }
+  if (subcategoriesError) {
+    console.error("Failed to fetch subcategories:", subcategoriesError);
+  }
+  if (peopleError) {
+    console.error("Failed to fetch people:", peopleError);
+  }
+  if (categoriesError) {
+    console.error("Failed to fetch categories:", categoriesError);
+  }
+
+  const typedSubcategories = (subcategories as Subcategory[]) || [];
+  const typedCategories = (categories as CategoryRecord[] | null) || [];
+
+  const fallbackEntries = typedCategories.map((category) => ({
+    id: category.id,
+    name: category.name,
+    image_url: category.image_url ?? null,
+    transaction_nature: category.transaction_nature,
+    categories: null,
+  }));
+
+  const combinedSubcategories = [...typedSubcategories];
+  const existingIds = new Set(combinedSubcategories.map((item) => item.id));
+  for (const entry of fallbackEntries) {
+    if (!existingIds.has(entry.id)) {
+      combinedSubcategories.push(entry);
+    }
   }
 
   return {
     accounts: (accounts as Account[]) || [],
-    subcategories: (subcategories as Subcategory[]) || [],
+    subcategories: combinedSubcategories,
     people: (people as Person[]) || [],
   };
 }
 
 export default async function AddTransactionPage() {
+  const t = createTranslator();
   const { accounts, subcategories, people } = await getFormData();
 
   return (
     <div>
-      <h1 className="text-3xl font-bold text-gray-800 mb-6">
-        Thêm Giao dịch mới
-      </h1>
+      <h1 className="text-3xl font-bold text-gray-800 mb-6">{t("transactionForm.title")}</h1>
       <div className="bg-white rounded-lg shadow-md">
         <TransactionForm
           accounts={accounts}

--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -1,89 +1,281 @@
 import Link from "next/link";
 
 import { supabase } from "@/lib/supabaseClient";
-import DeleteButton from "@/app/transactions/DeleteButton";
+import { createTranslator } from "@/lib/i18n";
 
-type TransactionRow = {
+import TransactionsView from "./TransactionsView";
+
+type NatureFilter = "all" | "income" | "expense" | "transfer";
+type MonthFilter = number | "all";
+type QuarterFilter = number | "all";
+
+type TransactionFilters = {
+  nature: NatureFilter;
+  year: number;
+  month: MonthFilter;
+  quarter: QuarterFilter;
+  accountId: string;
+  page: number;
+  pageSize: number;
+};
+
+type TransactionQueryRow = {
   id: string;
   date: string;
   amount: number;
   notes: string | null;
-  from_account?: { name: string | null } | null;
-  to_account?: { name: string | null } | null;
+  from_account_id: string | null;
+  to_account_id: string | null;
+  from_account?: { id: string | null; name: string | null; image_url: string | null } | null;
+  to_account?: { id: string | null; name: string | null; image_url: string | null } | null;
   subcategories?: {
+    id: string;
     name: string | null;
-    categories?: { name: string | null } | null;
+    transaction_nature?: string | null;
+    categories?:
+      | { name: string | null; transaction_nature?: string | null }[]
+      | { name: string | null; transaction_nature?: string | null }
+      | null;
   } | null;
 };
 
-async function getTransactions(): Promise<TransactionRow[]> {
-  const { data, error } = await supabase
-    .from("transactions")
-    .select(`
-      id,
-      date,
-      amount,
-      notes,
-      from_account:accounts!from_account_id ( name ),
-      to_account:accounts!to_account_id ( name ),
-      subcategories ( name, categories ( name ) )
-    `)
-    .order("date", { ascending: false });
+type TransactionListItem = {
+  id: string;
+  date: string;
+  amount: number;
+  notes: string | null;
+  fromAccount?: { id: string | null; name: string | null; image_url: string | null } | null;
+  toAccount?: { id: string | null; name: string | null; image_url: string | null } | null;
+  categoryName?: string | null;
+  subcategoryName?: string | null;
+  transactionNature?: string | null;
+};
 
-  if (error) {
-    console.error("Error fetching transactions:", error);
-    return [];
+type AccountRecord = {
+  id: string;
+  name: string;
+  image_url: string | null;
+  type: string | null;
+};
+
+const DEFAULT_PAGE_SIZE = 10;
+const PAGE_SIZE_OPTIONS = [10, 25, 50];
+const natureCodeMap: Record<Exclude<NatureFilter, "all">, string> = {
+  income: "IN",
+  expense: "EX",
+  transfer: "TR",
+};
+
+const now = new Date();
+const currentYear = now.getFullYear();
+const currentMonth = now.getMonth() + 1;
+const currentQuarter = Math.floor((currentMonth - 1) / 3) + 1;
+
+function parseNumber(value: string | undefined, fallback: number, min?: number, max?: number) {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isNaN(parsed)) {
+    return fallback;
   }
-  return (data as TransactionRow[]) || [];
+  if (min != null && parsed < min) return fallback;
+  if (max != null && parsed > max) return fallback;
+  return parsed;
 }
 
-export default async function TransactionsPage() {
-  const transactions = await getTransactions();
+function sanitizeFilters(searchParams?: Record<string, string | string[] | undefined>): TransactionFilters {
+  const params = searchParams ?? {};
+
+  const rawNature = typeof params.nature === "string" ? params.nature.toLowerCase() : "all";
+  const nature: NatureFilter = ["all", "income", "expense", "transfer"].includes(rawNature)
+    ? (rawNature as NatureFilter)
+    : "all";
+
+  const year = parseNumber(typeof params.year === "string" ? params.year : undefined, currentYear, 1970, currentYear + 10);
+
+  const monthParam = typeof params.month === "string" ? params.month.toLowerCase() : String(currentMonth);
+  let month: MonthFilter;
+  if (monthParam === "all") {
+    month = "all";
+  } else {
+    const parsed = parseNumber(monthParam, currentMonth, 1, 12);
+    month = parsed;
+  }
+
+  const quarterParam = typeof params.quarter === "string" ? params.quarter.toLowerCase() : String(currentQuarter);
+  let quarter: QuarterFilter;
+  if (quarterParam === "all") {
+    quarter = "all";
+  } else {
+    const parsed = parseNumber(quarterParam, currentQuarter, 1, 4);
+    quarter = parsed;
+  }
+
+  const accountId = typeof params.accountId === "string" ? params.accountId : "";
+
+  const page = parseNumber(typeof params.page === "string" ? params.page : undefined, 1, 1);
+
+  const rawPageSize = parseNumber(
+    typeof params.pageSize === "string" ? params.pageSize : undefined,
+    DEFAULT_PAGE_SIZE,
+    1
+  );
+  const pageSize = PAGE_SIZE_OPTIONS.includes(rawPageSize) ? rawPageSize : DEFAULT_PAGE_SIZE;
+
+  return {
+    nature,
+    year,
+    month,
+    quarter,
+    accountId,
+    page,
+    pageSize,
+  };
+}
+
+function getDateRange(filters: TransactionFilters) {
+  const { year, month, quarter } = filters;
+  let start = new Date(year, 0, 1);
+  let end = new Date(year + 1, 0, 1);
+
+  if (quarter !== "all") {
+    const startMonth = (quarter - 1) * 3;
+    start = new Date(year, startMonth, 1);
+    end = new Date(year, startMonth + 3, 1);
+  }
+
+  if (month !== "all") {
+    start = new Date(year, month - 1, 1);
+    end = new Date(year, month, 1);
+  }
+
+  return { start: start.toISOString(), end: end.toISOString() };
+}
+
+async function fetchTransactions(filters: TransactionFilters): Promise<{ rows: TransactionListItem[]; count: number }> {
+  const { start, end } = getDateRange(filters);
+
+  let query = supabase
+    .from("transactions")
+    .select(
+      `
+        id,
+        date,
+        amount,
+        notes,
+        from_account_id,
+        to_account_id,
+        from_account:accounts!from_account_id ( id, name, image_url ),
+        to_account:accounts!to_account_id ( id, name, image_url ),
+        subcategories (
+          id,
+          name,
+          transaction_nature,
+          categories (
+            name,
+            transaction_nature
+          )
+        )
+      `,
+      { count: "exact" }
+    )
+    .order("date", { ascending: false })
+    .gte("date", start)
+    .lt("date", end);
+
+  if (filters.accountId) {
+    query = query.or(`from_account_id.eq.${filters.accountId},to_account_id.eq.${filters.accountId}`);
+  }
+
+  if (filters.nature !== "all") {
+    const natureCode = natureCodeMap[filters.nature];
+    query = query.or(
+      `transaction_nature.eq.${natureCode},categories.transaction_nature.eq.${natureCode}`,
+      { foreignTable: "subcategories" }
+    );
+  }
+
+  const startIndex = (filters.page - 1) * filters.pageSize;
+  const endIndex = startIndex + filters.pageSize - 1;
+  query = query.range(startIndex, endIndex);
+
+  const { data, count, error } = await query;
+
+  if (error) {
+    console.error("Failed to fetch transactions:", error);
+    return { rows: [], count: 0 };
+  }
+
+  const rows = (data as TransactionQueryRow[]) || [];
+  const mapped: TransactionListItem[] = rows.map((row) => {
+    const subcategory = row.subcategories;
+    const rawCategories = subcategory?.categories;
+    const parentCategory = Array.isArray(rawCategories) ? rawCategories[0] : rawCategories ?? null;
+    const transactionNature =
+      subcategory?.transaction_nature ?? parentCategory?.transaction_nature ?? null;
+
+    return {
+      id: row.id,
+      date: row.date,
+      amount: row.amount,
+      notes: row.notes,
+      fromAccount: row.from_account ?? null,
+      toAccount: row.to_account ?? null,
+      categoryName: parentCategory?.name ?? null,
+      subcategoryName: subcategory?.name ?? null,
+      transactionNature,
+    };
+  });
+
+  return { rows: mapped, count: count ?? mapped.length };
+}
+
+async function fetchAccounts(): Promise<AccountRecord[]> {
+  const { data, error } = await supabase
+    .from("accounts")
+    .select("id, name, image_url, type")
+    .order("name", { ascending: true });
+
+  if (error) {
+    console.error("Failed to fetch accounts:", error);
+    return [];
+  }
+
+  return (data as AccountRecord[]) || [];
+}
+
+type TransactionsPageProps = {
+  searchParams?: Record<string, string | string[] | undefined>;
+};
+
+export default async function TransactionsPage({ searchParams }: TransactionsPageProps) {
+  const filters = sanitizeFilters(searchParams);
+  const t = createTranslator();
+
+  const [{ rows, count }, accounts] = await Promise.all([
+    fetchTransactions(filters),
+    fetchAccounts(),
+  ]);
 
   return (
     <div>
       <div className="flex justify-between items-center mb-6">
-        <h1 className="text-3xl font-bold text-gray-800">Lịch sử Giao dịch</h1>
+        <h1 className="text-3xl font-bold text-gray-800">{t("transactions.title")}</h1>
         <Link
           href="/transactions/add"
           className="bg-indigo-600 text-white font-medium py-2 px-4 rounded-lg hover:bg-indigo-700"
         >
-          + Thêm mới
+          {t("transactions.addButton")}
         </Link>
       </div>
 
-      <div className="bg-white rounded-lg shadow-md">
-        <div className="overflow-x-auto">
-          <table className="min-w-full divide-y-2 divide-gray-200 text-sm">
-            <thead>
-              <tr>
-                <th className="whitespace-nowrap px-4 py-2 text-left font-medium text-gray-900">Ngày</th>
-                <th className="whitespace-nowrap px-4 py-2 text-left font-medium text-gray-900">Danh mục</th>
-                <th className="whitespace-nowrap px-4 py-2 text-left font-medium text-gray-900">Tài khoản</th>
-                <th className="whitespace-nowrap px-4 py-2 text-left font-medium text-gray-900">Ghi chú</th>
-                <th className="whitespace-nowrap px-4 py-2 text-right font-medium text-gray-900">Số tiền</th>
-                <th className="px-4 py-2"></th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-200">
-              {transactions.map((tx: TransactionRow) => (
-                <tr key={tx.id}>
-                  <td className="whitespace-nowrap px-4 py-2 text-gray-700">{new Date(tx.date).toLocaleDateString('vi-VN')}</td>
-                  <td className="whitespace-nowrap px-4 py-2 text-gray-700">{tx.subcategories?.categories?.name} / {tx.subcategories?.name}</td>
-                  <td className="whitespace-nowrap px-4 py-2 text-gray-700">{tx.from_account?.name || tx.to_account?.name}</td>
-                  <td className="whitespace-nowrap px-4 py-2 text-gray-700">{tx.notes}</td>
-                  <td className="whitespace-nowrap px-4 py-2 text-right font-medium text-gray-900">
-                    {new Intl.NumberFormat('vi-VN', { style: 'currency', currency: 'VND' }).format(tx.amount)}
-                  </td>
-                  <td className="whitespace-nowrap px-4 py-2">
-                    <DeleteButton transactionId={tx.id} />
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      </div>
+      <TransactionsView
+        transactions={rows}
+        totalCount={count}
+        accounts={accounts}
+        filters={filters}
+      />
     </div>
   );
 }
+
+export type { TransactionListItem, TransactionFilters, AccountRecord };

--- a/src/components/AccountsTable.tsx
+++ b/src/components/AccountsTable.tsx
@@ -1,3 +1,5 @@
+import { createTranslator } from "@/lib/i18n";
+
 type Account = {
   id: string;
   name: string;
@@ -11,6 +13,8 @@ type AccountsTableProps = {
 };
 
 export default function AccountsTable({ accounts }: AccountsTableProps) {
+  const t = createTranslator();
+
   return (
     <div className="w-full mt-8">
       <div className="overflow-x-auto rounded-lg border border-gray-200">
@@ -18,13 +22,13 @@ export default function AccountsTable({ accounts }: AccountsTableProps) {
           <thead className="bg-gray-50">
             <tr>
               <th className="whitespace-nowrap px-4 py-2 text-left font-medium text-gray-900">
-                Tên Tài khoản
+                {t("accounts.name")}
               </th>
               <th className="whitespace-nowrap px-4 py-2 text-left font-medium text-gray-900">
-                Loại
+                {t("accounts.type")}
               </th>
               <th className="whitespace-nowrap px-4 py-2 text-left font-medium text-gray-900">
-                Hạn mức tín dụng
+                {t("accounts.creditLimit")}
               </th>
             </tr>
           </thead>
@@ -35,15 +39,15 @@ export default function AccountsTable({ accounts }: AccountsTableProps) {
                   {account.name}
                 </td>
                 <td className="whitespace-nowrap px-4 py-2 text-gray-700">
-                  {account.type || "N/A"}
+                  {account.type || t("accounts.notAvailable")}
                 </td>
                 <td className="whitespace-nowrap px-4 py-2 text-gray-700">
                   {account.credit_limit
-                    ? new Intl.NumberFormat("vi-VN", {
+                    ? new Intl.NumberFormat("en-US", {
                         style: "currency",
                         currency: "VND",
                       }).format(account.credit_limit)
-                    : "N/A"}
+                    : t("accounts.notAvailable")}
                 </td>
               </tr>
             ))}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,29 +1,33 @@
 import Link from "next/link";
 
+import { createTranslator } from "@/lib/i18n";
+
 export default function Sidebar() {
+  const t = createTranslator();
+
   return (
     <aside className="w-64 flex-shrink-0 bg-gray-800 p-4 text-white">
-      <h2 className="text-2xl font-bold mb-8">Gemini Money</h2>
+      <h2 className="text-2xl font-bold mb-8">{t("common.appName")}</h2>
       <nav>
         <ul>
           <li className="mb-4">
             <Link href="/" className="block p-2 rounded hover:bg-gray-700">
-              Dashboard
+              {t("sidebar.dashboard")}
             </Link>
           </li>
           <li className="mb-4">
             <Link href="/transactions" className="block p-2 rounded hover:bg-gray-700">
-              Giao dịch
+              {t("sidebar.transactions")}
             </Link>
           </li>
           <li className="mb-4">
             <Link href="/categories" className="block p-2 rounded hover:bg-gray-700">
-              Danh mục
+              {t("sidebar.categories")}
             </Link>
           </li>
           <li className="mb-4">
             <a href="#" className="block p-2 rounded hover:bg-gray-700">
-              Báo cáo
+              {t("sidebar.reports")}
             </a>
           </li>
         </ul>

--- a/src/components/categories/CategoryForm.tsx
+++ b/src/components/categories/CategoryForm.tsx
@@ -4,13 +4,15 @@ import { FormEvent, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 
 import { createCategory, TransactionNature } from "@/app/categories/actions";
+import { createTranslator, TranslationKey } from "@/lib/i18n";
 
-const natureOptions: { value: TransactionNature; label: string }[] = [
-  { value: "EX", label: "Chi tiêu" },
-  { value: "IN", label: "Thu nhập" },
-  { value: "TR", label: "Chuyển khoản" },
-  { value: "DE", label: "Công nợ" },
-];
+const natureValues: TransactionNature[] = ["EX", "IN", "TR", "DE"];
+const natureTranslationKeys: Record<TransactionNature, TranslationKey> = {
+  EX: "categories.nature.EX",
+  IN: "categories.nature.IN",
+  TR: "categories.nature.TR",
+  DE: "categories.nature.DE",
+};
 
 type CategoryFormProps = {
   returnTo: string;
@@ -19,12 +21,21 @@ type CategoryFormProps = {
 
 const getInitialNature = (defaultNature?: string): TransactionNature => {
   const normalized = (defaultNature || "").toUpperCase();
-  return natureOptions.find((option) => option.value === normalized)?.value ?? "EX";
+  return natureValues.find((value) => value === normalized) ?? "EX";
 };
 
 export default function CategoryForm({ returnTo, defaultNature }: CategoryFormProps) {
   const router = useRouter();
+  const t = createTranslator();
   const initialNature = useMemo(() => getInitialNature(defaultNature), [defaultNature]);
+  const natureOptions = useMemo(
+    () =>
+      natureValues.map((value) => ({
+        value,
+        label: t(natureTranslationKeys[value]),
+      })),
+    [t]
+  );
   const [name, setName] = useState("");
   const [imageUrl, setImageUrl] = useState("");
   const [transactionNature, setTransactionNature] = useState<TransactionNature>(initialNature);
@@ -37,7 +48,7 @@ export default function CategoryForm({ returnTo, defaultNature }: CategoryFormPr
 
   const handleBack = () => {
     if (isDirty) {
-      const shouldLeave = confirm("Bạn có chắc muốn quay lại? Thông tin chưa được lưu sẽ bị mất.");
+      const shouldLeave = confirm(t("categoryForm.confirmLeave"));
       if (!shouldLeave) {
         return;
       }
@@ -72,7 +83,7 @@ export default function CategoryForm({ returnTo, defaultNature }: CategoryFormPr
     <form onSubmit={handleSubmit} className="space-y-6">
       <div className="space-y-2">
         <label className="block text-sm font-medium text-gray-700" htmlFor="category-name">
-          Tên danh mục
+          {t("categoryForm.nameLabel")}
         </label>
         <input
           id="category-name"
@@ -80,14 +91,14 @@ export default function CategoryForm({ returnTo, defaultNature }: CategoryFormPr
           value={name}
           onChange={(event) => setName(event.target.value)}
           className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 py-3 px-4 text-base"
-          placeholder="Ví dụ: Ăn uống"
+          placeholder={t("categoryForm.namePlaceholder")}
           required
         />
       </div>
 
       <div className="space-y-2">
         <label className="block text-sm font-medium text-gray-700" htmlFor="category-nature">
-          Loại giao dịch
+          {t("categoryForm.typeLabel")}
         </label>
         <select
           id="category-nature"
@@ -105,7 +116,7 @@ export default function CategoryForm({ returnTo, defaultNature }: CategoryFormPr
 
       <div className="space-y-2">
         <label className="block text-sm font-medium text-gray-700" htmlFor="category-image">
-          Hình ảnh (URL)
+          {t("categoryForm.imageLabel")}
         </label>
         <input
           id="category-image"
@@ -115,7 +126,7 @@ export default function CategoryForm({ returnTo, defaultNature }: CategoryFormPr
           className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 py-3 px-4 text-base"
           placeholder="https://example.com/image.png"
         />
-        <p className="text-xs text-gray-500">Nhập đường dẫn ảnh biểu tượng cho danh mục (nếu có).</p>
+        <p className="text-xs text-gray-500">{t("categoryForm.imageHelp")}</p>
       </div>
 
       {errorMessage && (
@@ -128,14 +139,14 @@ export default function CategoryForm({ returnTo, defaultNature }: CategoryFormPr
           onClick={handleBack}
           className="px-4 py-2 rounded-md border border-gray-300 text-gray-700 hover:bg-gray-100"
         >
-          Quay lại
+          {t("categoryForm.back")}
         </button>
         <button
           type="submit"
           disabled={isSubmitting}
           className="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 py-2 px-4 text-base font-medium text-white shadow-sm hover:bg-indigo-700 disabled:opacity-60"
         >
-          {isSubmitting ? "Đang lưu..." : "Lưu danh mục"}
+          {isSubmitting ? t("categoryForm.saving") : t("categoryForm.save")}
         </button>
       </div>
     </form>

--- a/src/components/forms/AmountInput.tsx
+++ b/src/components/forms/AmountInput.tsx
@@ -1,34 +1,34 @@
 "use client";
 
 import { useState, useMemo } from "react";
-import Tooltip from "../ui/Tooltip";           // ✅ Tooltip
-import MiniCalculator from "./MiniCalculator"; // ✅ MiniCalculator
+import Tooltip from "../ui/Tooltip";
+import MiniCalculator from "./MiniCalculator";
+import { createTranslator } from "@/lib/i18n";
 
-// --- Helper functions (giữ & gọn) ---
 const formatNumber = (value: string) => {
   if (!value) return "";
-  const raw = value.replace(/\D/g, ""); // chỉ giữ số
+  const raw = value.replace(/\D/g, "");
   if (raw === "") return "";
-  const num = parseInt(raw, 10);        // bỏ số 0 ở đầu
+  const num = parseInt(raw, 10);
   return num.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
 };
 
-const toVietnameseWords = (numStr: string) => {
+const toReadableWords = (numStr: string) => {
   const num = parseInt(numStr.replace(/,/g, ""), 10);
   if (isNaN(num) || num === 0) return "";
   if (num >= 1_000_000_000)
-    return `${Math.floor(num / 1_000_000_000)} tỷ ${Math.floor(
+    return `${Math.floor(num / 1_000_000_000)} billion ${Math.floor(
       (num % 1_000_000_000) / 1_000_000
-    )} triệu...`;
+    )} million...`;
   if (num >= 1_000_000)
-    return `${Math.floor(num / 1_000_000)} triệu ${Math.floor(
+    return `${Math.floor(num / 1_000_000)} million ${Math.floor(
       (num % 1_000_000) / 1_000
-    )} ngàn...`;
+    )} thousand...`;
   if (num >= 1_000)
-    return `${Math.floor(num / 1_000)} ngàn ${
-      num % 1_000 > 0 ? `${num % 1_000} đồng...` : ""
+    return `${Math.floor(num / 1_000)} thousand ${
+      num % 1_000 > 0 ? `${num % 1_000} VND...` : ""
     }`;
-  return `${num} đồng`;
+  return `${num} VND`;
 };
 
 // --- Props ---
@@ -38,9 +38,9 @@ type AmountInputProps = {
 };
 
 export default function AmountInput({ value, onChange }: AmountInputProps) {
+  const t = createTranslator();
   const [showCalc, setShowCalc] = useState(false);
 
-  // Gợi ý nhanh theo chữ số đầu (giữ nguyên ý tưởng cũ)
   const suggestions = useMemo(() => {
     const firstDigit = value.charAt(0);
     if (!firstDigit || !/[1-9]/.test(firstDigit)) return [];
@@ -65,7 +65,7 @@ export default function AmountInput({ value, onChange }: AmountInputProps) {
         htmlFor="amount"
         className="block text-sm font-medium text-gray-700"
       >
-        Số tiền
+        {t("common.amount")}
       </label>
 
       <div className="mt-1 relative rounded-md shadow-sm">
@@ -82,10 +82,10 @@ export default function AmountInput({ value, onChange }: AmountInputProps) {
 
         {/* Action buttons (Calculator + Clear) */}
         <div className="absolute inset-y-0 right-0 pr-3 flex items-center space-x-2">
-          <Tooltip text="Mở máy tính mini">
+          <Tooltip text={t("amountInput.openCalculator")}>
             <button
               type="button"
-              aria-label="Mở máy tính mini"
+              aria-label={t("amountInput.openCalculatorAria")}
               onClick={() => setShowCalc((s) => !s)}
             >
               <svg
@@ -106,10 +106,10 @@ export default function AmountInput({ value, onChange }: AmountInputProps) {
           </Tooltip>
 
           {!!value && (
-            <Tooltip text="Xóa">
+            <Tooltip text={t("amountInput.clear")}>
               <button
                 type="button"
-                aria-label="Xóa số tiền"
+                aria-label={t("amountInput.clearAria")}
                 onClick={handleClear}
                 className="text-gray-400 hover:text-gray-600"
               >
@@ -130,17 +130,15 @@ export default function AmountInput({ value, onChange }: AmountInputProps) {
           )}
         </div>
 
-        {/* MiniCalculator (đặt trong container relative để dễ định vị nếu cần) */}
         {showCalc && (
           <MiniCalculator
             initialValue={value}
-            onApply={onChange}            // Trả giá trị về input
+            onApply={onChange}
             onClose={() => setShowCalc(false)}
           />
         )}
       </div>
 
-      {/* Gợi ý & chữ đọc số (giữ nguyên) */}
       <div className="mt-2 flex justify-between items-center h-8">
         <div className="flex space-x-2">
           {suggestions.map((sugg) => (
@@ -155,7 +153,7 @@ export default function AmountInput({ value, onChange }: AmountInputProps) {
           ))}
         </div>
         <div className="text-sm text-gray-500 italic">
-          {toVietnameseWords(value)}
+          {toReadableWords(value)}
         </div>
       </div>
     </div>

--- a/src/components/forms/CashbackInput.tsx
+++ b/src/components/forms/CashbackInput.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useMemo, useCallback } from "react";
 import { Account } from "@/app/transactions/add/page";
+import { createTranslator } from "@/lib/i18n";
 
 type LastEdited = "percent" | "amount" | null;
 
@@ -29,7 +30,7 @@ const parsePercent = (value: string) => {
 
 const formatCurrency = (value: number) => {
   if (!value) return "0";
-  return value.toLocaleString("vi-VN");
+  return `${value.toLocaleString("en-US")} VND`;
 };
 
 const formatPercent = (value: number) => {
@@ -39,6 +40,7 @@ const formatPercent = (value: number) => {
 };
 
 export default function CashbackInput({ transactionAmount, account, onCashbackChange }: CashbackInputProps) {
+  const t = createTranslator();
   const [percentInput, setPercentInput] = useState<string>("");
   const [amountInput, setAmountInput] = useState<string>("");
   const [lastEdited, setLastEdited] = useState<LastEdited>(null);
@@ -246,34 +248,34 @@ export default function CashbackInput({ transactionAmount, account, onCashbackCh
 
   const hintMessage = useMemo(() => {
     if (!account.is_cashback_eligible) {
-      return `Thẻ ${account.name} không hỗ trợ cashback.`;
+      return `Card ${account.name} does not support cashback.`;
     }
 
     if (transactionValue <= 0) {
-      return "Nhập số tiền giao dịch để hệ thống tính giới hạn cashback.";
+      return "Enter the transaction amount to calculate cashback limits.";
     }
 
     const limitParts: string[] = [];
     if (accountPercentLimit != null) {
-      limitParts.push(`Tỷ lệ tối đa ${formatPercent(accountPercentLimit)}%`);
+      limitParts.push(`Maximum rate ${formatPercent(accountPercentLimit)}%`);
     }
     if (account.max_cashback_amount != null) {
-      limitParts.push(`Hoàn tiền tối đa ${formatCurrency(Math.floor(account.max_cashback_amount))}đ`);
+      limitParts.push(`Maximum cashback ${formatCurrency(Math.floor(account.max_cashback_amount))}`);
     }
 
     const limitPrefix =
       limitParts.length > 0
-        ? `Giới hạn thẻ: ${limitParts.join(" • ")}.`
-        : "Thẻ này chưa có thông tin giới hạn cashback cụ thể.";
+        ? `Card limits: ${limitParts.join(" • ")}.`
+        : "This card does not have specific cashback limit information.";
 
     if (amountLimit <= 0) {
-      return `${limitPrefix} Giao dịch ${formatCurrency(transactionValue)}đ hiện không đủ điều kiện nhận cashback.`;
+      return `${limitPrefix} A ${formatCurrency(transactionValue)} transaction is currently not eligible for cashback.`;
     }
 
     const effectivePercent = transactionValue > 0 ? (amountLimit / transactionValue) * 100 : 0;
-    const detail = `Với giao dịch ${formatCurrency(transactionValue)}đ bạn chỉ có thể nhận tối đa ${formatCurrency(
+    const detail = `For a ${formatCurrency(transactionValue)} transaction you can earn up to ${formatCurrency(
       amountLimit
-    )}đ (~${formatPercent(effectivePercent)}%).`;
+    )} (~${formatPercent(effectivePercent)}%).`;
 
     return `${limitPrefix} ${detail}`;
   }, [
@@ -288,17 +290,17 @@ export default function CashbackInput({ transactionAmount, account, onCashbackCh
   return (
     <div className="p-4 bg-blue-50 border border-blue-200 rounded-lg space-y-4">
       <div className="flex items-center justify-between">
-        <p className="text-sm font-medium text-blue-800">Thông tin Cashback</p>
+        <p className="text-sm font-medium text-blue-800">{t("transactionForm.labels.cashbackInfo")}</p>
         {canEdit && amountLimit > 0 && (
           <span className="text-xs font-medium text-blue-700">
-            Tối đa {formatCurrency(amountLimit)}đ (~{formatPercent((amountLimit / transactionValue) * 100)}%)
+            Up to {formatCurrency(amountLimit)} (~{formatPercent((amountLimit / transactionValue) * 100)}%)
           </span>
         )}
       </div>
 
       {!canEdit && (
         <div className="text-xs text-blue-700 bg-blue-100 p-2 rounded-md">
-          Nhập số tiền giao dịch trước khi thêm thông tin cashback.
+          Enter the transaction amount before adding cashback details.
         </div>
       )}
 
@@ -326,21 +328,21 @@ export default function CashbackInput({ transactionAmount, account, onCashbackCh
             <>
               <p className="mt-1 text-xs text-gray-500">
                 {percentInput
-                  ? `Tương đương khoảng ${formatCurrency(amountSuggestion)}đ hoàn tiền.`
+                  ? `Equivalent to about ${formatCurrency(amountSuggestion)} in cashback.`
                   : amountLimit > 0
-                  ? `Gợi ý: tối đa ${formatPercent(effectivePercentLimit)}% để nhận ${formatCurrency(amountLimit)}đ.`
-                  : "Giao dịch này hiện chưa có tỷ lệ hoàn tiền khả dụng."}
+                  ? `Suggestion: up to ${formatPercent(effectivePercentLimit)}% to earn ${formatCurrency(amountLimit)}.`
+                  : "No cashback rate is available for this transaction."}
               </p>
               {percentExceeded && (
                 <p className="mt-1 text-xs text-red-600">
-                  Không thể vượt quá {formatPercent(effectivePercentLimit)}% vì giới hạn của thẻ hoặc số tiền giao dịch.
+                  Cannot exceed {formatPercent(effectivePercentLimit)}% due to card or transaction limits.
                 </p>
               )}
             </>
           )}
         </div>
         <div>
-          <label className="block text-xs text-gray-600 mb-1">Cashback (đồng)</label>
+          <label className="block text-xs text-gray-600 mb-1">Cashback (VND)</label>
           <input
             type="text"
             inputMode="numeric"
@@ -354,14 +356,14 @@ export default function CashbackInput({ transactionAmount, account, onCashbackCh
             <>
               <p className="mt-1 text-xs text-gray-500">
                 {amountInput
-                  ? `Tương đương khoảng ${formatPercent(percentSuggestion)}%.`
+                  ? `Equivalent to roughly ${formatPercent(percentSuggestion)}%.`
                   : amountLimit > 0
-                  ? `Gợi ý: số tiền hoàn tối đa là ${formatCurrency(amountLimit)}đ.`
-                  : "Chưa có khoản hoàn tiền khả dụng cho giao dịch này."}
+                  ? `Suggestion: the maximum cashback amount is ${formatCurrency(amountLimit)}.`
+                  : "No cashback amount is available for this transaction."}
               </p>
               {amountExceeded && (
                 <p className="mt-1 text-xs text-red-600">
-                  Không thể vượt quá {formatCurrency(amountLimit)}đ vì giới hạn của thẻ hoặc giao dịch.
+                  Cannot exceed {formatCurrency(amountLimit)} because of card or transaction limits.
                 </p>
               )}
             </>

--- a/src/components/forms/CustomSelect.tsx
+++ b/src/components/forms/CustomSelect.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { Listbox, Transition } from '@headlessui/react';
-// SỬA Ở ĐÂY: Import lại component Image
 import Image from 'next/image';
 import { Fragment, useState, useMemo, useEffect, useRef } from 'react';
+import { createTranslator } from '@/lib/i18n';
 
 export type Option = { id: string; name: string; imageUrl?: string; type?: string; };
 type CustomSelectProps = {
@@ -23,6 +23,7 @@ const SearchIcon = () => <svg className="h-5 w-5 text-gray-400" xmlns="http://ww
 const ADD_NEW_VALUE = "__add_new__";
 
 export default function CustomSelect({ label, value, onChange, options, required = false, defaultTab, onAddNew, addNewLabel }: CustomSelectProps) {
+  const t = createTranslator();
   const [query, setQuery] = useState('');
   const [activeTab, setActiveTab] = useState('All');
   const appliedDefaultRef = useRef(false);
@@ -74,14 +75,13 @@ export default function CustomSelect({ label, value, onChange, options, required
       <Listbox value={value} onChange={handleSelect}>
         <Listbox.Label className="block text-sm font-medium text-gray-700">
           {label}
-          {required && <span className="ml-1 text-red-500">*</span>}
+          {required && <span className="ml-1 text-red-500">{t("common.requiredIndicator")}</span>}
         </Listbox.Label>
         <div className="mt-1 relative">
           <Listbox.Button className="relative w-full bg-white border border-gray-300 rounded-md shadow-sm pl-3 pr-10 py-3 text-left cursor-default focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm">
             <span className="flex items-center">
-              {/* SỬA Ở ĐÂY: Dùng lại <Image> */}
               {selectedOption?.imageUrl && <Image src={selectedOption.imageUrl} alt={selectedOption.name} width={24} height={24} className="flex-shrink-0 h-6 w-6" />}
-              <span className={`ml-3 block truncate ${!selectedOption ? 'text-gray-500' : ''}`}>{selectedOption ? selectedOption.name : `Chọn ${label.toLowerCase()}`}</span>
+              <span className={`ml-3 block truncate ${!selectedOption ? 'text-gray-500' : ''}`}>{selectedOption ? selectedOption.name : `Select ${label.toLowerCase()}`}</span>
             </span>
             <span className="ml-3 absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none"><SelectorIcon /></span>
           </Listbox.Button>
@@ -89,13 +89,13 @@ export default function CustomSelect({ label, value, onChange, options, required
           <Transition as={Fragment} leave="transition ease-in duration-100" leaveFrom="opacity-100" leaveTo="opacity-0">
             <Listbox.Options className="absolute z-10 mt-1 w-full bg-white shadow-lg max-h-60 rounded-md py-1 text-base ring-1 ring-black ring-opacity-5 overflow-auto focus:outline-none sm:text-sm">
               <div className="p-2">
-                <div className="relative"><span className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"><SearchIcon /></span><input type="text" placeholder="Tìm kiếm..." className="w-full bg-gray-50 rounded-md border-gray-300 pl-10 pr-4 py-2 focus:ring-indigo-500 focus:border-indigo-500" onChange={(e) => setQuery(e.target.value)} /></div>
+                <div className="relative"><span className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none"><SearchIcon /></span><input type="text" placeholder={t("common.searchPlaceholder")} className="w-full bg-gray-50 rounded-md border-gray-300 pl-10 pr-4 py-2 focus:ring-indigo-500 focus:border-indigo-500" onChange={(e) => setQuery(e.target.value)} /></div>
               </div>
-              
+
               {accountTypes.length > 2 && ( // Chỉ hiện tab nếu có nhiều hơn 1 loại tài khoản
                 <div className="flex border-b border-gray-200 px-2">
                   {accountTypes.map(type => (
-                    <button key={type} type="button" onClick={(e) => { e.stopPropagation(); setActiveTab(type); }} className={`px-3 py-1.5 text-sm font-medium border-b-2 ${activeTab === type ? 'border-indigo-500 text-indigo-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'}`}>{type}</button>
+                    <button key={type} type="button" onClick={(e) => { e.stopPropagation(); setActiveTab(type); }} className={`px-3 py-1.5 text-sm font-medium border-b-2 ${activeTab === type ? 'border-indigo-500 text-indigo-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'}`}>{type === 'All' ? t("transactions.tabs.all") : type}</button>
                   ))}
                 </div>
               )}
@@ -104,14 +104,13 @@ export default function CustomSelect({ label, value, onChange, options, required
                 {filteredOptions.map(option => (
                   <Listbox.Option key={option.id} className={({ active }) => `cursor-pointer select-none relative py-2 pl-3 pr-9 ${active ? 'text-white bg-indigo-600' : 'text-gray-900'}`} value={option.id}>
                     <div className="flex items-center">
-                       {/* SỬA Ở ĐÂY: Dùng lại <Image> */}
                       {option.imageUrl && <Image src={option.imageUrl} alt={option.name} width={24} height={24} className="flex-shrink-0 h-6 w-6" />}
                       <span className="font-normal ml-3 block truncate">{option.name}</span>
                     </div>
                   </Listbox.Option>
                 ))}
               </div>
-              
+
               {hasAddNew && (
                 <Listbox.Option
                   value={ADD_NEW_VALUE}
@@ -121,7 +120,7 @@ export default function CustomSelect({ label, value, onChange, options, required
                     }`
                   }
                 >
-                  + {addNewLabel ?? 'Thêm mới...'}
+                  + {addNewLabel ?? `${t("common.addNew")}...`}
                 </Listbox.Option>
               )}
             </Listbox.Options>

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,0 +1,341 @@
+export type Locale = "en" | "vi";
+
+export const DEFAULT_LOCALE: Locale = "en";
+
+const resources = {
+  en: {
+    common: {
+      appName: "Gemini Money",
+      addNew: "Add New",
+      add: "Add",
+      cancel: "Cancel",
+      save: "Save",
+      back: "Back",
+      loading: "Saving...",
+      notes: "Notes",
+      amount: "Amount",
+      date: "Date",
+      searchPlaceholder: "Search...",
+      noData: "No data available.",
+      actions: "Actions",
+      requiredIndicator: "*",
+    },
+    sidebar: {
+      dashboard: "Dashboard",
+      transactions: "Transactions",
+      categories: "Categories",
+      reports: "Reports",
+    },
+    dashboard: {
+      title: "Dashboard",
+      accountsHeading: "Accounts",
+      incomeThisMonth: "Income This Month",
+      expenseThisMonth: "Expenses This Month",
+      currentBalance: "Current Balance",
+    },
+    accounts: {
+      name: "Account Name",
+      type: "Type",
+      creditLimit: "Credit Limit",
+      notAvailable: "N/A",
+    },
+    transactions: {
+      title: "Transaction History",
+      addButton: "+ Add New",
+      tableHeaders: {
+        select: "Select",
+        date: "Date",
+        category: "Category",
+        account: "Account",
+        notes: "Notes",
+        amount: "Amount",
+      },
+      tabs: {
+        all: "All",
+        income: "Income",
+        expense: "Expenses",
+        transfer: "Transfers",
+      },
+      filters: {
+        year: "Year",
+        month: "Month",
+        quarter: "Quarter",
+        account: "Account",
+        apply: "Apply Filters",
+        reset: "Reset",
+        showOnlySelected: "Show selected only",
+        selectAll: "Select All",
+        allAccounts: "All accounts",
+        pageSize: "Rows per page",
+      },
+      emptyState: "No transactions found.",
+      pagination: {
+        previous: "Previous",
+        next: "Next",
+        pageLabel: "Page",
+        of: "of",
+      },
+    },
+    transactionForm: {
+      title: "Add New Transaction",
+      tabs: {
+        expense: "Expenses",
+        income: "Income",
+        transfer: "Transfers",
+        debt: "Debt",
+      },
+      labels: {
+        fromAccount: "From Account",
+        toAccount: "To Account",
+        expenseCategory: "Expense Category",
+        incomeCategory: "Income Category",
+        transferCategory: "Transfer Category",
+        whoOwes: "Who owes?",
+        withdrawFromAccount: "Withdraw From Account",
+        cashbackInfo: "Cashback Information",
+      },
+      actions: {
+        submit: "Save Transaction",
+        submitting: "Saving...",
+      },
+      addCategory: {
+        expense: "Add Expense Category",
+        income: "Add Income Category",
+        transfer: "Add Transfer Category",
+        debt: "Add Debt Category",
+      },
+      errors: {
+        sameTransferAccount: "You cannot transfer between the same account.",
+      },
+    },
+    amountInput: {
+      openCalculator: "Open mini calculator",
+      openCalculatorAria: "Open mini calculator",
+      clear: "Clear",
+      clearAria: "Clear amount",
+    },
+    categories: {
+      title: "Categories",
+      addButton: "+ Add New",
+      tableHeaders: {
+        icon: "Icon",
+        name: "Category Name",
+        type: "Transaction Type",
+      },
+      emptyState: "No categories available.",
+      nature: {
+        EX: "Expenses",
+        IN: "Income",
+        TR: "Transfers",
+        DE: "Debt",
+        unknown: "Unknown",
+      },
+    },
+    categoryForm: {
+      title: "Add New Category",
+      nameLabel: "Category Name",
+      namePlaceholder: "Example: Transportation",
+      typeLabel: "Transaction Type",
+      imageLabel: "Image (URL)",
+      imageHelp: "Provide an image URL for the category icon (optional).",
+      back: "Back",
+      save: "Save Category",
+      confirmLeave: "Are you sure you want to go back? Unsaved changes will be lost.",
+      saving: "Saving...",
+    },
+    delete: {
+      confirm: "Are you sure you want to delete this transaction?",
+      success: "Transaction deleted successfully!",
+      error: "Error",
+      button: "Delete",
+    },
+  },
+  vi: {
+    common: {
+      appName: "Gemini Money",
+      addNew: "Thêm mới",
+      add: "Thêm",
+      cancel: "Hủy",
+      save: "Lưu",
+      back: "Quay lại",
+      loading: "Đang lưu...",
+      notes: "Ghi chú",
+      amount: "Số tiền",
+      date: "Ngày",
+      searchPlaceholder: "Tìm kiếm...",
+      noData: "Chưa có dữ liệu.",
+      actions: "Thao tác",
+      requiredIndicator: "*",
+    },
+    sidebar: {
+      dashboard: "Dashboard",
+      transactions: "Giao dịch",
+      categories: "Danh mục",
+      reports: "Báo cáo",
+    },
+    dashboard: {
+      title: "Dashboard",
+      accountsHeading: "Tài khoản",
+      incomeThisMonth: "Thu nhập Tháng này",
+      expenseThisMonth: "Chi tiêu Tháng này",
+      currentBalance: "Số dư Hiện tại",
+    },
+    accounts: {
+      name: "Tên Tài khoản",
+      type: "Loại",
+      creditLimit: "Hạn mức tín dụng",
+      notAvailable: "Không có",
+    },
+    transactions: {
+      title: "Lịch sử Giao dịch",
+      addButton: "+ Thêm mới",
+      tableHeaders: {
+        select: "Chọn",
+        date: "Ngày",
+        category: "Danh mục",
+        account: "Tài khoản",
+        notes: "Ghi chú",
+        amount: "Số tiền",
+      },
+      tabs: {
+        all: "Tất cả",
+        income: "Thu nhập",
+        expense: "Chi tiêu",
+        transfer: "Chuyển khoản",
+      },
+      filters: {
+        year: "Năm",
+        month: "Tháng",
+        quarter: "Quý",
+        account: "Tài khoản",
+        apply: "Áp dụng bộ lọc",
+        reset: "Đặt lại",
+        showOnlySelected: "Chỉ hiển thị mục đã chọn",
+        selectAll: "Chọn tất cả",
+        allAccounts: "Tất cả tài khoản",
+        pageSize: "Số dòng mỗi trang",
+      },
+      emptyState: "Chưa có giao dịch nào.",
+      pagination: {
+        previous: "Trước",
+        next: "Tiếp",
+        pageLabel: "Trang",
+        of: "trên",
+      },
+    },
+    transactionForm: {
+      title: "Thêm Giao dịch mới",
+      tabs: {
+        expense: "Chi tiêu",
+        income: "Thu nhập",
+        transfer: "Chuyển khoản",
+        debt: "Công nợ",
+      },
+      labels: {
+        fromAccount: "Từ Tài khoản",
+        toAccount: "Đến Tài khoản",
+        expenseCategory: "Danh mục Chi tiêu",
+        incomeCategory: "Danh mục Thu nhập",
+        transferCategory: "Danh mục Chuyển khoản",
+        whoOwes: "Ai nợ?",
+        withdrawFromAccount: "Rút tiền từ Tài khoản",
+        cashbackInfo: "Thông tin Cashback",
+      },
+      actions: {
+        submit: "Lưu Giao dịch",
+        submitting: "Đang lưu...",
+      },
+      addCategory: {
+        expense: "Thêm danh mục Chi tiêu",
+        income: "Thêm danh mục Thu nhập",
+        transfer: "Thêm danh mục Chuyển khoản",
+        debt: "Thêm danh mục Công nợ",
+      },
+      errors: {
+        sameTransferAccount: "Không thể chuyển khoản trong cùng một tài khoản.",
+      },
+    },
+    amountInput: {
+      openCalculator: "Mở máy tính mini",
+      openCalculatorAria: "Mở máy tính mini",
+      clear: "Xóa",
+      clearAria: "Xóa số tiền",
+    },
+    categories: {
+      title: "Danh mục",
+      addButton: "+ Thêm mới",
+      tableHeaders: {
+        icon: "Biểu tượng",
+        name: "Tên danh mục",
+        type: "Loại giao dịch",
+      },
+      emptyState: "Chưa có danh mục nào.",
+      nature: {
+        EX: "Chi tiêu",
+        IN: "Thu nhập",
+        TR: "Chuyển khoản",
+        DE: "Công nợ",
+        unknown: "Không xác định",
+      },
+    },
+    categoryForm: {
+      title: "Thêm danh mục mới",
+      nameLabel: "Tên danh mục",
+      namePlaceholder: "Ví dụ: Di chuyển",
+      typeLabel: "Loại giao dịch",
+      imageLabel: "Hình ảnh (URL)",
+      imageHelp: "Nhập đường dẫn ảnh biểu tượng cho danh mục (nếu có).",
+      back: "Quay lại",
+      save: "Lưu danh mục",
+      confirmLeave: "Bạn có chắc muốn quay lại? Thông tin chưa được lưu sẽ bị mất.",
+      saving: "Đang lưu...",
+    },
+    delete: {
+      confirm: "Bạn có chắc chắn muốn xóa giao dịch này không?",
+      success: "Xóa giao dịch thành công!",
+      error: "Lỗi",
+      button: "Xóa",
+    },
+  },
+} as const;
+
+type Resource = typeof resources;
+type NestedKeyOf<ObjectType extends object> = {
+  [Key in keyof ObjectType & (string | number)]: ObjectType[Key] extends object
+    ? `${Key}.${NestedKeyOf<ObjectType[Key]>}`
+    : Key;
+}[keyof ObjectType & (string | number)];
+
+export type TranslationKey = NestedKeyOf<Resource[Locale]>;
+
+function resolvePath(locale: Locale, path: string) {
+  const segments = path.split(".");
+  let current: unknown = resources[locale];
+  for (const segment of segments) {
+    if (current == null || typeof current !== "object") {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[segment];
+  }
+  return current;
+}
+
+export function translate(path: TranslationKey, locale: Locale = DEFAULT_LOCALE): string {
+  const value = resolvePath(locale, path);
+  if (typeof value === "string") {
+    return value;
+  }
+  const fallback = resolvePath(DEFAULT_LOCALE, path);
+  if (typeof fallback === "string") {
+    return fallback;
+  }
+  return path;
+}
+
+export function createTranslator(locale: Locale = DEFAULT_LOCALE) {
+  return (path: TranslationKey) => translate(path, locale);
+}
+
+export function getResources(locale: Locale = DEFAULT_LOCALE) {
+  return resources[locale] ?? resources[DEFAULT_LOCALE];
+}

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,8 +1,8 @@
 import { createClient } from '@supabase/supabase-js'
 
-// Lấy các biến môi trường đã tạo ở file .env.local
+// Read Supabase credentials from environment variables
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
 
-// Khởi tạo và export một client Supabase duy nhất để dùng trong toàn bộ ứng dụng
-export const supabase = createClient(supabaseUrl, supabaseAnonKey)
+// Create and export a single Supabase client for the entire application
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);


### PR DESCRIPTION
## Summary
- add a centralized translation dictionary and update the dashboard, sidebar, forms, and feedback messages to use English copy
- refactor the transactions list with reusable client filters, account dropdown reuse, tab persistence, pagination, and bulk selection support
- restore category data display via fallback queries, translate category management, and allow remote account images from i.postimg.cc

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3dda58450832990e458c3d46509c0