### PR TITLE
Fix Supabase queries and support remote images

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,33 +1,4 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-  images: {
-    remotePatterns: [
-      {
-        protocol: 'https',
-        hostname: 'www.investmentexecutive.com',
-        port: '',
-        pathname: '/**',
-      },
-      {
-        protocol: 'https',
-        hostname: 'cdn-icons-png.flaticon.com',
-        port: '',
-        pathname: '/**',
-      },
-      {
-        protocol: 'https',
-        hostname: 'uxwing.com',
-        port: '',
-        pathname: '/**',
-      },
-      {
-        protocol: 'https',
-        hostname: 'i.postimg.cc',
-        port: '',
-        pathname: '/**',
-      },
-    ],
-  },
-};
+const nextConfig = {};
 
 module.exports = nextConfig;

--- a/src/app/categories/actions.ts
+++ b/src/app/categories/actions.ts
@@ -42,7 +42,7 @@ export async function createCategory(input: CreateCategoryInput): Promise<Action
   };
 
   const { data, error } = await supabase
-    .from("subcategories")
+    .from("categories")
     .insert(payload)
     .select("id")
     .single();

--- a/src/app/categories/page.tsx
+++ b/src/app/categories/page.tsx
@@ -1,8 +1,8 @@
-import Image from "next/image";
 import Link from "next/link";
 
 import { supabase } from "@/lib/supabaseClient";
 import { createTranslator } from "@/lib/i18n";
+import RemoteImage from "@/components/RemoteImage";
 
 type CategoryRecord = {
   id: string;
@@ -26,7 +26,7 @@ const getNatureLabel = (value: string | undefined | null, t: ReturnType<typeof c
 async function getCategories() {
   const { data, error } = await supabase
     .from("subcategories")
-    .select("id, name, image_url, transaction_nature, categories(transaction_nature)")
+    .select("id, name, image_url, categories(transaction_nature)")
     .order("name", { ascending: true });
 
   if (error) {
@@ -94,7 +94,7 @@ export default async function CategoriesPage() {
                   <tr key={category.id}>
                     <td className="px-4 py-3">
                       {category.image_url ? (
-                        <Image
+                        <RemoteImage
                           src={category.image_url}
                           alt={category.name}
                           width={32}

--- a/src/app/transactions/add/page.tsx
+++ b/src/app/transactions/add/page.tsx
@@ -41,7 +41,7 @@ async function getFormData() {
   const accountsPromise = supabase.from("accounts").select("id, name, image_url, type, is_cashback_eligible, cashback_percentage, max_cashback_amount");
   const subcategoriesPromise = supabase
     .from("subcategories")
-    .select("id, name, image_url, transaction_nature, categories(name, transaction_nature)");
+    .select("id, name, image_url, categories(name, transaction_nature)");
   const peoplePromise = supabase.from("people").select("id, name, image_url, is_group");
   const categoriesPromise = supabase.from("categories").select("id, name, transaction_nature, image_url");
 

--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -31,7 +31,6 @@ type TransactionQueryRow = {
   subcategories?: {
     id: string;
     name: string | null;
-    transaction_nature?: string | null;
     categories?:
       | { name: string | null; transaction_nature?: string | null }[]
       | { name: string | null; transaction_nature?: string | null }
@@ -169,7 +168,6 @@ async function fetchTransactions(filters: TransactionFilters): Promise<{ rows: T
         subcategories (
           id,
           name,
-          transaction_nature,
           categories (
             name,
             transaction_nature
@@ -188,10 +186,7 @@ async function fetchTransactions(filters: TransactionFilters): Promise<{ rows: T
 
   if (filters.nature !== "all") {
     const natureCode = natureCodeMap[filters.nature];
-    query = query.or(
-      `transaction_nature.eq.${natureCode},categories.transaction_nature.eq.${natureCode}`,
-      { foreignTable: "subcategories" }
-    );
+    query = query.eq("categories.transaction_nature", natureCode, { foreignTable: "subcategories" });
   }
 
   const startIndex = (filters.page - 1) * filters.pageSize;
@@ -210,8 +205,7 @@ async function fetchTransactions(filters: TransactionFilters): Promise<{ rows: T
     const subcategory = row.subcategories;
     const rawCategories = subcategory?.categories;
     const parentCategory = Array.isArray(rawCategories) ? rawCategories[0] : rawCategories ?? null;
-    const transactionNature =
-      subcategory?.transaction_nature ?? parentCategory?.transaction_nature ?? null;
+    const transactionNature = parentCategory?.transaction_nature ?? null;
 
     return {
       id: row.id,

--- a/src/components/RemoteImage.tsx
+++ b/src/components/RemoteImage.tsx
@@ -1,0 +1,39 @@
+/* eslint-disable @next/next/no-img-element */
+"use client";
+
+import Image from "next/image";
+
+type RemoteImageProps = {
+  src?: string | null;
+  alt: string;
+  width?: number;
+  height?: number;
+  className?: string;
+};
+
+const isRemoteUrl = (value: string) => /^https?:\/\//i.test(value);
+
+export default function RemoteImage({ src, alt, width, height, className }: RemoteImageProps) {
+  if (!src) {
+    return null;
+  }
+
+  if (isRemoteUrl(src)) {
+    return (
+      <img
+        src={src}
+        alt={alt}
+        width={width}
+        height={height}
+        loading="lazy"
+        className={className}
+        referrerPolicy="no-referrer"
+      />
+    );
+  }
+
+  const resolvedWidth = width ?? 24;
+  const resolvedHeight = height ?? resolvedWidth;
+
+  return <Image src={src} alt={alt} width={resolvedWidth} height={resolvedHeight} className={className} />;
+}

--- a/src/components/forms/CustomSelect.tsx
+++ b/src/components/forms/CustomSelect.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { Listbox, Transition } from '@headlessui/react';
-import Image from 'next/image';
 import { Fragment, useState, useMemo, useEffect, useRef } from 'react';
 import { createTranslator } from '@/lib/i18n';
+import RemoteImage from '@/components/RemoteImage';
 
 export type Option = { id: string; name: string; imageUrl?: string; type?: string; };
 type CustomSelectProps = {
@@ -80,7 +80,15 @@ export default function CustomSelect({ label, value, onChange, options, required
         <div className="mt-1 relative">
           <Listbox.Button className="relative w-full bg-white border border-gray-300 rounded-md shadow-sm pl-3 pr-10 py-3 text-left cursor-default focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm">
             <span className="flex items-center">
-              {selectedOption?.imageUrl && <Image src={selectedOption.imageUrl} alt={selectedOption.name} width={24} height={24} className="flex-shrink-0 h-6 w-6" />}
+              {selectedOption?.imageUrl && (
+                <RemoteImage
+                  src={selectedOption.imageUrl}
+                  alt={selectedOption.name}
+                  width={24}
+                  height={24}
+                  className="flex-shrink-0 h-6 w-6"
+                />
+              )}
               <span className={`ml-3 block truncate ${!selectedOption ? 'text-gray-500' : ''}`}>{selectedOption ? selectedOption.name : `Select ${label.toLowerCase()}`}</span>
             </span>
             <span className="ml-3 absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none"><SelectorIcon /></span>
@@ -104,7 +112,15 @@ export default function CustomSelect({ label, value, onChange, options, required
                 {filteredOptions.map(option => (
                   <Listbox.Option key={option.id} className={({ active }) => `cursor-pointer select-none relative py-2 pl-3 pr-9 ${active ? 'text-white bg-indigo-600' : 'text-gray-900'}`} value={option.id}>
                     <div className="flex items-center">
-                      {option.imageUrl && <Image src={option.imageUrl} alt={option.name} width={24} height={24} className="flex-shrink-0 h-6 w-6" />}
+                      {option.imageUrl && (
+                        <RemoteImage
+                          src={option.imageUrl}
+                          alt={option.name}
+                          width={24}
+                          height={24}
+                          className="flex-shrink-0 h-6 w-6"
+                        />
+                      )}
                       <span className="font-normal ml-3 block truncate">{option.name}</span>
                     </div>
                   </Listbox.Option>


### PR DESCRIPTION
## Summary
- add a shared RemoteImage helper and remove hard-coded Next.js image host restrictions so any remote URL can be rendered
- align category and transaction Supabase queries with the actual schema and update filtering logic
- create categories in the correct table and keep downstream views working with the updated shapes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3f24ddc9c83299cde0bfa6d592c81