### PR TITLE
Handle missing Supabase config gracefully

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,4 @@
-import { supabase } from "@/lib/supabaseClient";
+import { supabase, supabaseConfigurationError } from "@/lib/supabaseClient";
 import AccountsTable from "@/components/AccountsTable";
 import StatCard from "@/components/StatCard";
 import { createTranslator } from "@/lib/i18n";
@@ -28,23 +28,49 @@ type TransactionRecord = {
 
 export default async function Home() {
   const t = createTranslator();
-  const { data: accountsData } = await supabase.from("accounts").select();
-  const { data: transactionsData } = await supabase
-    .from("transactions")
-    .select(`
-      amount,
-      date,
-      subcategories (
-        categories (
-          transaction_nature
+  let accountsData: Account[] | null = null;
+  let transactionsData: TransactionRecord[] | null = null;
+  let errorMessage: string | undefined;
+
+  if (!supabase) {
+    errorMessage = supabaseConfigurationError?.message ?? "Supabase client is not configured.";
+    console.error("Unable to load dashboard data:", errorMessage);
+  } else {
+    const [{ data: accountResponse, error: accountsError }, { data: transactionResponse, error: transactionsError }] =
+      await Promise.all([
+        supabase.from("accounts").select(),
+        supabase
+          .from("transactions")
+          .select(`
+        amount,
+        date,
+        subcategories (
+          categories (
+            transaction_nature
+          )
         )
-      )
-    `);
+      `),
+      ]);
+
+    if (accountsError) {
+      errorMessage = accountsError.message || "Unable to fetch accounts.";
+      console.error("Unable to fetch accounts:", accountsError);
+    }
+
+    if (transactionsError) {
+      const message = transactionsError.message || "Unable to fetch transactions.";
+      errorMessage = errorMessage ? `${errorMessage} ${message}` : message;
+      console.error("Unable to fetch transactions:", transactionsError);
+    }
+
+    accountsData = (accountResponse as Account[]) || [];
+    transactionsData = (transactionResponse as TransactionRecord[]) || [];
+  }
 
   const now = new Date();
   const currentMonthStart = new Date(now.getFullYear(), now.getMonth(), 1);
 
-  const transactions = (transactionsData as TransactionRecord[]) || [];
+  const transactions = transactionsData || [];
 
   const monthlyTransactions = transactions.filter(tx => new Date(tx.date) >= currentMonthStart);
   
@@ -67,6 +93,12 @@ export default async function Home() {
   return (
     <div>
       <h1 className="text-3xl font-bold text-gray-800 mb-6">{t("dashboard.title")}</h1>
+
+      {errorMessage && (
+        <div className="mb-6 rounded border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-700">
+          {errorMessage}
+        </div>
+      )}
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
         <StatCard title={t("dashboard.incomeThisMonth")} value={formatCurrency(totalIncomeThisMonth)} type="income" />

--- a/src/app/transactions/TransactionsView.tsx
+++ b/src/app/transactions/TransactionsView.tsx
@@ -17,6 +17,7 @@ type TransactionsViewProps = {
   totalCount: number;
   accounts: AccountRecord[];
   filters: TransactionFilters;
+  errorMessage?: string;
 };
 
 type NatureTab = {
@@ -239,7 +240,7 @@ function DeleteSelectedButton({ selectedIds, onDeleted }: DeleteSelectedButtonPr
   );
 }
 
-export default function TransactionsView({ transactions, totalCount, accounts, filters }: TransactionsViewProps) {
+export default function TransactionsView({ transactions, totalCount, accounts, filters, errorMessage }: TransactionsViewProps) {
   const t = createTranslator();
   const router = useRouter();
   const pathname = usePathname();
@@ -431,13 +432,15 @@ export default function TransactionsView({ transactions, totalCount, accounts, f
       return prev;
     });
     setColumnWidths((prev) => {
+      let didMutate = false;
       const next = { ...prev };
       Object.keys(next).forEach((key) => {
         if (!availableIds.includes(key as DataColumnId)) {
           delete next[key as DataColumnId];
+          didMutate = true;
         }
       });
-      return next;
+      return didMutate ? next : prev;
     });
   }, [dataColumns]);
 
@@ -721,6 +724,11 @@ export default function TransactionsView({ transactions, totalCount, accounts, f
       )}
 
       <div className="rounded-lg border border-gray-200 bg-white shadow-sm">
+        {errorMessage && (
+          <div className="border-b border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-700">
+            {errorMessage}
+          </div>
+        )}
         <div className="border-b border-gray-200 bg-gray-50">
           <div className="space-y-6 p-4">
             <div className="flex justify-end">

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,8 +1,39 @@
-import { createClient } from '@supabase/supabase-js'
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 
-// Read Supabase credentials from environment variables
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
-// Create and export a single Supabase client for the entire application
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+type SupabaseClientType = SupabaseClient | null;
+
+let client: SupabaseClientType = null;
+let configurationError: Error | null = null;
+
+if (supabaseUrl && supabaseAnonKey) {
+  client = createClient(supabaseUrl, supabaseAnonKey);
+} else {
+  const missingEnvVars = [
+    !supabaseUrl ? "NEXT_PUBLIC_SUPABASE_URL" : null,
+    !supabaseAnonKey ? "NEXT_PUBLIC_SUPABASE_ANON_KEY" : null,
+  ].filter(Boolean);
+
+  configurationError = new Error(
+    `Missing Supabase environment variables: ${missingEnvVars.join(", ")}`
+  );
+
+  if (process.env.NODE_ENV !== "production") {
+    console.warn(
+      `[Supabase] Falling back to safe defaults because ${configurationError.message}.`
+    );
+  }
+}
+
+export const supabase = client;
+export const supabaseConfigurationError = configurationError;
+export const isSupabaseConfigured = client !== null;
+
+export function requireSupabaseClient() {
+  if (!client) {
+    throw configurationError ?? new Error("Supabase client is not configured.");
+  }
+  return client;
+}


### PR DESCRIPTION
## Summary
- add guardrails around Supabase client creation to detect missing configuration and expose helper state
- surface fetch failures on the dashboard, transactions, and categories pages with safe fallbacks and warning banners
- prevent the transactions table customization effect from looping by only updating column widths when they actually change

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4c394dd988329ad82b28eeff48a06