### PR TITLE
Normalize transaction nature handling and polish filters

### DIFF
--- a/src/app/transactions/TransactionsView.tsx
+++ b/src/app/transactions/TransactionsView.tsx
@@ -78,7 +78,7 @@ const formatDate = (date: string) => new Date(date).toLocaleDateString("en-US");
 const amountColorMap: Record<string, string> = {
   EX: "text-red-600",
   IN: "text-green-700",
-  TR: "text-blue-600",
+  TF: "text-blue-600",
 };
 
 const MAX_TOOLTIP_WORDS_PER_LINE = 6;
@@ -377,6 +377,7 @@ export default function TransactionsView({ transactions, totalCount, accounts, f
   const resetHighlightTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [showLoading, setShowLoading] = useState(false);
   const [searchValue, setSearchValue] = useState(filters.searchTerm);
+  const searchInputRef = useRef<HTMLInputElement | null>(null);
   const defaultTemporalValues = useMemo(() => {
     const now = new Date();
     const month = now.getMonth() + 1;
@@ -817,7 +818,7 @@ export default function TransactionsView({ transactions, totalCount, accounts, f
   ]);
 
   const resetButtonClasses = useMemo(() => {
-    const base = "w-full rounded-md px-3 py-2 text-sm font-medium shadow-sm transition md:w-auto";
+    const base = "inline-flex items-center justify-center rounded-md px-3 py-2 text-sm font-medium shadow-sm transition";
     const activeState = resetHighlighted
       ? "border border-indigo-500 bg-indigo-600 text-white shadow"
       : "border border-gray-300 bg-white text-gray-700 hover:bg-gray-100";
@@ -858,6 +859,11 @@ export default function TransactionsView({ transactions, totalCount, accounts, f
     }, 400);
     return () => clearTimeout(timeout);
   }, [filters.searchTerm, searchValue, updateFilters]);
+
+  const handleSearchClear = useCallback(() => {
+    setSearchValue("");
+    searchInputRef.current?.focus();
+  }, []);
 
   const handleSelectAll = () => {
     setSelectedIds((prev) => {
@@ -1066,7 +1072,7 @@ export default function TransactionsView({ transactions, totalCount, accounts, f
               </div>
 
               <div className="flex flex-col gap-4">
-              <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+              <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
                   <div className="flex flex-col gap-2 md:flex-1">
                     <CustomSelect
                       label={t("transactions.filters.account")}
@@ -1076,15 +1082,6 @@ export default function TransactionsView({ transactions, totalCount, accounts, f
                     />
                   </div>
                   <div className="flex flex-wrap items-center gap-3 md:justify-end">
-                    {filters.accountId && (
-                      <button
-                        type="button"
-                        onClick={() => updateFilters({ accountId: undefined })}
-                        className="text-xs font-semibold uppercase tracking-wide text-indigo-600 transition hover:text-indigo-800"
-                      >
-                        {t("transactions.filters.allAccounts")}
-                      </button>
-                    )}
                     <button
                       type="button"
                       onClick={handleReset}
@@ -1108,18 +1105,39 @@ export default function TransactionsView({ transactions, totalCount, accounts, f
           <div className="flex flex-col gap-4 border-b border-gray-200 bg-gray-50 px-4 py-4">
             <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
               <div className="w-full md:max-w-sm md:flex-1">
-                <input
-                  type="search"
-                  value={searchValue}
-                  onChange={(event) => setSearchValue(event.target.value)}
-                  placeholder={t("common.searchPlaceholder")}
-                  aria-label={t("common.searchPlaceholder")}
-                  className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
-                />
+                <div className="relative">
+                  <input
+                    ref={searchInputRef}
+                    type="search"
+                    value={searchValue}
+                    onChange={(event) => setSearchValue(event.target.value)}
+                    placeholder={t("common.searchPlaceholder")}
+                    aria-label={t("common.searchPlaceholder")}
+                    className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 pr-24 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                  />
+                  {searchValue ? (
+                    <button
+                      type="button"
+                      onClick={handleSearchClear}
+                      className="absolute inset-y-1.5 right-2 inline-flex items-center rounded-md border border-transparent px-2 text-xs font-semibold uppercase tracking-wide text-indigo-600 transition hover:border-indigo-100 hover:bg-indigo-50"
+                      aria-label={t("common.clear")}
+                    >
+                      {t("common.clear")}
+                    </button>
+                  ) : null}
+                </div>
               </div>
             </div>
             <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
               <div className="flex flex-wrap items-center gap-2">
+                <Tooltip label={t("transactions.actions.addTooltip")}>
+                  <Link
+                    href="/transactions/add"
+                    className="inline-flex items-center gap-2 rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-indigo-700"
+                  >
+                    {t("transactions.addButton")}
+                  </Link>
+                </Tooltip>
                 {natureTabs.map((tab) => {
                   const palette = natureTabPalette[tab.value];
                   const isActive = filters.nature === tab.value;
@@ -1148,14 +1166,6 @@ export default function TransactionsView({ transactions, totalCount, accounts, f
                     <span aria-hidden="true">×</span>
                   </button>
                 )}
-                <Tooltip label={t("transactions.actions.addTooltip")}>
-                  <Link
-                    href="/transactions/add"
-                    className="inline-flex items-center gap-2 rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-indigo-700"
-                  >
-                    {t("transactions.addButton")}
-                  </Link>
-                </Tooltip>
                 <DeleteSelectedButton selectedIds={selectedIdsArray} onDeleted={clearSelection} />
                 {selectedIdsArray.length > 0 && (
                   <button

--- a/src/app/transactions/actions.ts
+++ b/src/app/transactions/actions.ts
@@ -36,12 +36,10 @@ export async function createTransaction(data: TransactionData) {
   // Validate cashback input if provided
   let cashbackPercent: number | null = null;
   let cashbackAmount: number | null = null;
-  let cashbackSource: "percent" | "amount" | null = null;
 
   if (data.cashback) {
     const { percent, amount, source } = data.cashback;
     const inputSource = source === "percent" || source === "amount" ? source : null;
-    cashbackSource = inputSource;
 
     // Coerce NaN -> invalid
     const pct = Number(percent);
@@ -134,7 +132,6 @@ export async function createTransaction(data: TransactionData) {
     // Cashback fields
     cashback_percent: cashbackPercent,
     cashback_amount: cashbackAmount,
-    cashback_source: cashbackSource,
     // Final amount after cashback
     final_price: finalPrice,
   };

--- a/src/app/transactions/constants.ts
+++ b/src/app/transactions/constants.ts
@@ -3,8 +3,8 @@ import type { NatureFilter } from "./types";
 export const DEFAULT_PAGE_SIZE = 10;
 export const PAGE_SIZE_OPTIONS = [5, 10, 25, 50] as const;
 
-export const natureCodeMap: Record<Exclude<NatureFilter, "all">, "IN" | "EX" | "TR"> = {
+export const natureCodeMap: Record<Exclude<NatureFilter, "all">, "IN" | "EX" | "TF"> = {
   income: "IN",
   expense: "EX",
-  transfer: "TR",
+  transfer: "TF",
 };

--- a/src/components/AccountsTable.tsx
+++ b/src/components/AccountsTable.tsx
@@ -1,11 +1,106 @@
+import RemoteImage from "@/components/RemoteImage";
 import { createTranslator } from "@/lib/i18n";
+
+const currencyFormatter = new Intl.NumberFormat("vi-VN", {
+  style: "currency",
+  currency: "VND",
+  maximumFractionDigits: 0,
+});
+
+const dateFormatter = new Intl.DateTimeFormat("vi-VN", { dateStyle: "medium" });
+
+const formatAccountType = (value: string | null | undefined, fallback: string) => {
+  if (!value) {
+    return fallback;
+  }
+  const cleaned = value.replace(/[_-]+/g, " ").trim();
+  if (!cleaned) {
+    return fallback;
+  }
+  return cleaned
+    .split(" ")
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+};
+
+const getInitials = (value: string) => {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "?";
+  }
+  const parts = trimmed.split(/\s+/);
+  if (parts.length === 1) {
+    return parts[0].slice(0, 2).toUpperCase();
+  }
+  return `${parts[0].charAt(0)}${parts[parts.length - 1].charAt(0)}`.toUpperCase();
+};
+
+const formatCreditLimit = (value: number | null | undefined, fallback: string) => {
+  if (value == null || Number.isNaN(value)) {
+    return fallback;
+  }
+  return currencyFormatter.format(value);
+};
+
+const formatPercent = (value: number | null | undefined) => {
+  if (value == null || Number.isNaN(value)) {
+    return null;
+  }
+  const fixed = Number.parseFloat(value.toString());
+  if (Number.isNaN(fixed)) {
+    return null;
+  }
+  const normalized = Math.abs(fixed) <= 1 ? fixed * 100 : fixed;
+  const rounded = Number(normalized.toFixed(2));
+  const stringValue = Number.isInteger(rounded)
+    ? rounded.toString()
+    : rounded.toFixed(1);
+  return `${stringValue.replace(/\.0$/, "")}%`;
+};
+
+const formatCashback = (
+  account: Account,
+  t: ReturnType<typeof createTranslator>
+) => {
+  if (!account.is_cashback_eligible) {
+    return t("accounts.cashbackNotEligible");
+  }
+
+  const percentLabel = formatPercent(account.cashback_percentage ?? null);
+  const amountLabel =
+    account.max_cashback_amount != null && !Number.isNaN(account.max_cashback_amount)
+      ? currencyFormatter.format(account.max_cashback_amount)
+      : null;
+
+  const parts = [percentLabel, amountLabel].filter((part): part is string => Boolean(part));
+  if (parts.length === 0) {
+    return t("accounts.notAvailable");
+  }
+  return parts.join(" • ");
+};
+
+const formatCreatedAt = (value: string | null | undefined, fallback: string) => {
+  if (!value) {
+    return fallback;
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return fallback;
+  }
+  return dateFormatter.format(parsed);
+};
 
 type Account = {
   id: string;
   name: string;
+  image_url: string | null;
   type: string | null;
   credit_limit: number | null;
-  created_at: string;
+  created_at?: string | null;
+  is_cashback_eligible?: boolean | null;
+  cashback_percentage?: number | null;
+  max_cashback_amount?: number | null;
 };
 
 type AccountsTableProps = {
@@ -15,45 +110,79 @@ type AccountsTableProps = {
 export default function AccountsTable({ accounts }: AccountsTableProps) {
   const t = createTranslator();
 
-  return (
-    <div className="w-full mt-8">
-      <div className="overflow-x-auto rounded-lg border border-gray-200">
-        <table className="min-w-full divide-y-2 divide-gray-200 bg-white text-sm">
-          <thead className="bg-gray-50">
-            <tr>
-              <th className="whitespace-nowrap px-4 py-2 text-left font-medium text-gray-900">
-                {t("accounts.name")}
-              </th>
-              <th className="whitespace-nowrap px-4 py-2 text-left font-medium text-gray-900">
-                {t("accounts.type")}
-              </th>
-              <th className="whitespace-nowrap px-4 py-2 text-left font-medium text-gray-900">
-                {t("accounts.creditLimit")}
-              </th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-gray-200">
-            {accounts.map((account) => (
-              <tr key={account.id}>
-                <td className="whitespace-nowrap px-4 py-2 font-medium text-gray-900">
-                  {account.name}
-                </td>
-                <td className="whitespace-nowrap px-4 py-2 text-gray-700">
-                  {account.type || t("accounts.notAvailable")}
-                </td>
-                <td className="whitespace-nowrap px-4 py-2 text-gray-700">
-                  {account.credit_limit
-                    ? new Intl.NumberFormat("en-US", {
-                        style: "currency",
-                        currency: "VND",
-                      }).format(account.credit_limit)
-                    : t("accounts.notAvailable")}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+  if (!accounts.length) {
+    return (
+      <div className="mt-8 rounded-lg border border-gray-200 bg-white px-6 py-8 text-center text-sm text-gray-500">
+        {t("common.noData")}
       </div>
+    );
+  }
+
+  return (
+    <div className="mt-8 overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+      <table className="min-w-full divide-y divide-gray-200 text-sm">
+        <thead className="bg-gray-50">
+          <tr>
+            <th className="px-4 py-3 text-left font-semibold uppercase tracking-wide text-gray-600">
+              {t("accounts.name")}
+            </th>
+            <th className="px-4 py-3 text-left font-semibold uppercase tracking-wide text-gray-600">
+              {t("accounts.type")}
+            </th>
+            <th className="px-4 py-3 text-left font-semibold uppercase tracking-wide text-gray-600">
+              {t("accounts.creditLimit")}
+            </th>
+            <th className="px-4 py-3 text-left font-semibold uppercase tracking-wide text-gray-600">
+              {t("accounts.cashback")}
+            </th>
+            <th className="px-4 py-3 text-left font-semibold uppercase tracking-wide text-gray-600">
+              {t("accounts.created")}
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-200 bg-white">
+          {accounts.map((account) => {
+            const typeLabel = formatAccountType(account.type, t("accounts.notAvailable"));
+            const creditLimitLabel = formatCreditLimit(account.credit_limit, t("accounts.notAvailable"));
+            const cashbackLabel = formatCashback(account, t);
+            const createdLabel = formatCreatedAt(account.created_at ?? null, t("accounts.notAvailable"));
+
+            return (
+              <tr key={account.id} className="transition hover:bg-indigo-50/40">
+                <td className="px-4 py-3">
+                  <div className="flex items-center gap-3">
+                    {account.image_url ? (
+                      <RemoteImage
+                        src={account.image_url}
+                        alt={account.name}
+                        width={48}
+                        height={48}
+                        className="h-12 w-12 rounded-full object-cover"
+                      />
+                    ) : (
+                      <span className="flex h-12 w-12 items-center justify-center rounded-full bg-indigo-100 text-sm font-semibold uppercase text-indigo-700">
+                        {getInitials(account.name)}
+                      </span>
+                    )}
+                    <div>
+                      <div className="font-medium text-gray-900">{account.name}</div>
+                      <div className="text-xs text-gray-500">{account.id}</div>
+                    </div>
+                  </div>
+                </td>
+                <td className="px-4 py-3">
+                  <span className="inline-flex items-center rounded-full border border-gray-200 bg-gray-100 px-2.5 py-1 text-xs font-medium text-gray-700">
+                    {typeLabel}
+                  </span>
+                </td>
+                <td className="px-4 py-3 text-gray-700">{creditLimitLabel}</td>
+                <td className="px-4 py-3 text-gray-700">{cashbackLabel}</td>
+                <td className="px-4 py-3 text-gray-700">{createdLabel}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
     </div>
   );
 }

--- a/src/components/categories/CategoryForm.tsx
+++ b/src/components/categories/CategoryForm.tsx
@@ -6,12 +6,13 @@ import { useRouter } from "next/navigation";
 import { createCategory, TransactionNature } from "@/app/categories/actions";
 import { useAppShell } from "@/components/AppShellProvider";
 import { createTranslator, TranslationKey } from "@/lib/i18n";
+import { normalizeTransactionNature } from "@/lib/transactionNature";
 
-const natureValues: TransactionNature[] = ["EX", "IN", "TR", "DE"];
+const natureValues: TransactionNature[] = ["EX", "IN", "TF", "DE"];
 const natureTranslationKeys: Record<TransactionNature, TranslationKey> = {
   EX: "categories.nature.EX",
   IN: "categories.nature.IN",
-  TR: "categories.nature.TR",
+  TF: "categories.nature.TF",
   DE: "categories.nature.DE",
 };
 
@@ -21,8 +22,7 @@ type CategoryFormProps = {
 };
 
 const getInitialNature = (defaultNature?: string): TransactionNature => {
-  const normalized = (defaultNature || "").toUpperCase();
-  return natureValues.find((value) => value === normalized) ?? "EX";
+  return normalizeTransactionNature(defaultNature ?? null) ?? "EX";
 };
 
 export default function CategoryForm({ returnTo, defaultNature }: CategoryFormProps) {

--- a/src/components/forms/CustomSelect.tsx
+++ b/src/components/forms/CustomSelect.tsx
@@ -109,7 +109,7 @@ export default function CustomSelect({ label, value, onChange, options, required
             leaveTo="opacity-0"
             afterLeave={() => setQuery('')}
           >
-            <Listbox.Options as="div" className="absolute z-10 mt-1 w-full overflow-hidden rounded-md border border-gray-200 bg-white text-sm shadow-lg">
+            <Listbox.Options as="div" className="absolute z-40 mt-1 w-full overflow-hidden rounded-md border border-gray-200 bg-white text-sm shadow-lg">
               <div className="sticky top-0 z-10 space-y-2 border-b border-gray-200 bg-white p-2">
                 <div className="relative">
                   <span className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
@@ -119,10 +119,23 @@ export default function CustomSelect({ label, value, onChange, options, required
                     ref={searchInputRef}
                     type="text"
                     placeholder={t("common.searchPlaceholder")}
-                    className="w-full rounded-md border border-gray-300 bg-gray-50 py-2 pl-10 pr-4 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                    className="w-full rounded-md border border-gray-300 bg-gray-50 py-2 pl-10 pr-20 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
                     value={query}
                     onChange={(e) => setQuery(e.target.value)}
                   />
+                  {query ? (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setQuery("");
+                        searchInputRef.current?.focus();
+                      }}
+                      className="absolute inset-y-1 right-2 inline-flex items-center rounded-md border border-transparent px-2 text-xs font-semibold uppercase tracking-wide text-indigo-600 transition hover:border-indigo-100 hover:bg-indigo-50"
+                      aria-label={t("common.clear")}
+                    >
+                      {t("common.clear")}
+                    </button>
+                  ) : null}
                 </div>
 
                 {accountTypes.length > 2 && (

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -20,7 +20,7 @@ export type DashboardAccount = {
 export type DashboardTransactionRecord = {
   amount: number;
   date: string;
-  transactionNature: "IN" | "EX" | "TR";
+  transactionNature: "IN" | "EX" | "TF";
 };
 
 type MockTransactionSeed = {
@@ -37,15 +37,15 @@ type MockTransactionSeed = {
   person?: { id: string; name: string; image_url: string | null } | null;
   categoryName: string | null;
   subcategoryName: string | null;
-  transactionNature: "IN" | "EX" | "TR";
+  transactionNature: "IN" | "EX" | "TF";
 };
 
 type MockSubcategory = {
   id: string;
   name: string;
   image_url: string | null;
-  transaction_nature: "EX" | "IN" | "TR" | "DE";
-  categories: { name: string; transaction_nature: "EX" | "IN" | "TR" | "DE" }[];
+  transaction_nature: "EX" | "IN" | "TF" | "DE";
+  categories: { name: string; transaction_nature: "EX" | "IN" | "TF" | "DE" }[];
 };
 
 type MockPerson = {
@@ -158,7 +158,7 @@ const mockTransactions: MockTransactionSeed[] = [
     toAccountId: "acc-investment",
     categoryName: "Transfer",
     subcategoryName: "Investments",
-    transactionNature: "TR",
+    transactionNature: "TF",
   },
   {
     id: "tx-1005",
@@ -211,8 +211,8 @@ const mockSubcategories: MockSubcategory[] = [
     id: "sub-investments",
     name: "Investments",
     image_url: null,
-    transaction_nature: "TR",
-    categories: [{ name: "Transfers", transaction_nature: "TR" }],
+    transaction_nature: "TF",
+    categories: [{ name: "Transfers", transaction_nature: "TF" }],
   },
   {
     id: "sub-rent",

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -17,6 +17,7 @@ const resources = {
       amount: "Amount",
       date: "Date",
       searchPlaceholder: "Search...",
+      clear: "Clear",
       noData: "No data available.",
       actions: "Actions",
       requiredIndicator: "*",
@@ -39,6 +40,9 @@ const resources = {
       name: "Account Name",
       type: "Type",
       creditLimit: "Credit Limit",
+      cashback: "Cashback",
+      created: "Opened",
+      cashbackNotEligible: "Not eligible",
       notAvailable: "N/A",
     },
     transactions: {
@@ -204,7 +208,7 @@ const resources = {
       nature: {
         EX: "Expenses",
         IN: "Income",
-        TR: "Transfers",
+        TF: "Transfers",
         DE: "Debt",
         unknown: "Unknown",
       },
@@ -218,6 +222,9 @@ const resources = {
       actions: {
         editTooltip: "Edit category",
         deleteTooltip: "Delete category",
+        deleteConfirm: "Delete this category?",
+        deleteSuccess: "Category deleted successfully.",
+        deleteError: "Unable to delete the selected category.",
       },
     },
     categoryForm: {
@@ -253,6 +260,7 @@ const resources = {
       amount: "Số tiền",
       date: "Ngày",
       searchPlaceholder: "Tìm kiếm...",
+      clear: "Xóa",
       noData: "Chưa có dữ liệu.",
       actions: "Thao tác",
       requiredIndicator: "*",
@@ -275,6 +283,9 @@ const resources = {
       name: "Tên Tài khoản",
       type: "Loại",
       creditLimit: "Hạn mức tín dụng",
+      cashback: "Hoàn tiền",
+      created: "Ngày mở",
+      cashbackNotEligible: "Không áp dụng",
       notAvailable: "Không có",
     },
     transactions: {
@@ -440,7 +451,7 @@ const resources = {
       nature: {
         EX: "Chi tiêu",
         IN: "Thu nhập",
-        TR: "Chuyển khoản",
+        TF: "Chuyển khoản",
         DE: "Công nợ",
         unknown: "Không xác định",
       },
@@ -454,6 +465,9 @@ const resources = {
       actions: {
         editTooltip: "Chỉnh sửa danh mục",
         deleteTooltip: "Xóa danh mục",
+        deleteConfirm: "Bạn có chắc muốn xóa danh mục này?",
+        deleteSuccess: "Đã xóa danh mục thành công.",
+        deleteError: "Không thể xóa danh mục đã chọn.",
       },
     },
     categoryForm: {

--- a/src/lib/transactionNature.ts
+++ b/src/lib/transactionNature.ts
@@ -1,0 +1,56 @@
+export type TransactionNatureCode = "EX" | "IN" | "TF" | "DE";
+
+const aliasMap: Record<string, TransactionNatureCode> = {
+  EX: "EX",
+  EXPENSE: "EX",
+  EXPENSES: "EX",
+  EXP: "EX",
+  IN: "IN",
+  INCOME: "IN",
+  INCOMES: "IN",
+  INC: "IN",
+  TF: "TF",
+  TR: "TF",
+  TRANSFER: "TF",
+  TRANSFERS: "TF",
+  TRANS: "TF",
+  DE: "DE",
+  DEBT: "DE",
+  DEBTS: "DE",
+  DEBIT: "DE",
+};
+
+const databaseNatureMap: Record<TransactionNatureCode, string[]> = {
+  EX: ["EX", "Expense", "Expenses"],
+  IN: ["IN", "Income", "Incomes"],
+  TF: ["TF", "Transfer", "Transfers"],
+  DE: ["DE", "Debt", "Debts"],
+};
+
+export function normalizeTransactionNature(
+  value?: string | null
+): TransactionNatureCode | null {
+  if (!value) {
+    return null;
+  }
+  const key = value.toString().trim().toUpperCase();
+  return aliasMap[key] ?? null;
+}
+
+export function resolveTransactionNature(
+  value: string | null | undefined,
+  fallback: TransactionNatureCode
+): TransactionNatureCode {
+  return normalizeTransactionNature(value) ?? fallback;
+}
+
+export function getDatabaseNatureCandidates(
+  nature: TransactionNatureCode
+): string[] {
+  const candidates = databaseNatureMap[nature] ?? [nature];
+  return Array.from(new Set(candidates.map((candidate) => candidate.trim()))).filter(Boolean);
+}
+
+export function includesTransferNature(value?: string | null): boolean {
+  return normalizeTransactionNature(value) === "TF";
+}


### PR DESCRIPTION
## Summary
- add a shared transaction nature normalizer and retry logic so Supabase accepts transfer categories and subcategories
- propagate normalized nature codes across category, transaction, and people fetches while tightening the filter queries
- tweak filter UI polish by removing the stray “All accounts” badge, adding clear buttons to dropdown search, and keeping add buttons on one line

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d57052cef08329ac9e83b559827675