### PR TITLE
Improve people filters and add shop selection

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,8 +6,8 @@ import AppShell from "@/components/AppShell"; // Import AppShell
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
-  title: "gemini",
-  description: "Personal Finance Management App",
+  title: "Money Flow",
+  description: "Money Flow personal finance management app",
 };
 
 export default function RootLayout({

--- a/src/app/transactions/actions.ts
+++ b/src/app/transactions/actions.ts
@@ -22,6 +22,7 @@ type TransactionData = {
   date: string;
   cashback: CashbackData | null; // include cashback information
   debtMode?: "collect" | "lend";
+  shopId?: string | null;
 };
 
 export async function createTransaction(data: TransactionData) {
@@ -135,6 +136,8 @@ export async function createTransaction(data: TransactionData) {
     // Final amount after cashback
     final_price: finalPrice,
   };
+
+  transactionToInsert.shop_id = data.shopId ?? null;
 
   // Tab-specific handling
   if (data.activeTab === "expense") {

--- a/src/app/transactions/add/page.tsx
+++ b/src/app/transactions/add/page.tsx
@@ -24,6 +24,7 @@ export type Subcategory = {
   image_url: string | null;
   transaction_nature?: string | null;
   categories: CategoryInfo[] | CategoryInfo | null;
+  is_shop?: boolean | null;
 };
 type CategoryRecord = {
   id: string;
@@ -57,6 +58,7 @@ async function getFormData() {
         name: subcategory.name,
         image_url: subcategory.image_url,
         transaction_nature: normalizeTransactionNature(subcategory.transaction_nature ?? null) ?? null,
+        is_shop: subcategory.is_shop ?? false,
         categories: Array.isArray(subcategory.categories)
           ? subcategory.categories.map((category) => ({
               ...category,
@@ -84,7 +86,7 @@ async function getFormData() {
     .select("id, name, image_url, type, is_cashback_eligible, cashback_percentage, max_cashback_amount");
   const subcategoriesPromise = supabase
     .from("subcategories")
-    .select("id, name, image_url, categories(name, transaction_nature)");
+    .select("id, name, image_url, is_shop, categories(name, transaction_nature)");
   const peoplePromise = supabase.from("people").select("id, name, image_url, is_group");
   const categoriesPromise = supabase.from("categories").select("id, name, transaction_nature, image_url");
 
@@ -121,6 +123,7 @@ async function getFormData() {
       name: category.name,
       image_url: category.image_url ?? null,
       transaction_nature: normalizedNature,
+      is_shop: false,
       categories: [
         {
           name: category.name,

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -55,7 +55,12 @@ export default function Sidebar() {
   return (
     <aside className="w-64 flex-shrink-0 border-r border-gray-200 bg-gray-900 text-white">
       <div className="px-6 py-8">
-        <h2 className="text-2xl font-bold tracking-tight">{t("common.appName")}</h2>
+        <div className="flex items-center gap-3">
+          <span className="flex h-10 w-10 items-center justify-center rounded-full bg-emerald-500 text-xl font-bold text-white shadow-lg shadow-emerald-500/40">
+            ₫
+          </span>
+          <h2 className="text-2xl font-bold tracking-tight">{t("common.appName")}</h2>
+        </div>
       </div>
       <nav>
         <ul className="space-y-1 px-4 pb-6">

--- a/src/components/forms/AmountInput.tsx
+++ b/src/components/forms/AmountInput.tsx
@@ -14,21 +14,42 @@ const formatNumber = (value: string) => {
 };
 
 const toReadableWords = (numStr: string) => {
-  const num = parseInt(numStr.replace(/,/g, ""), 10);
-  if (isNaN(num) || num === 0) return "";
-  if (num >= 1_000_000_000)
-    return `${Math.floor(num / 1_000_000_000)} billion ${Math.floor(
-      (num % 1_000_000_000) / 1_000_000
-    )} million...`;
-  if (num >= 1_000_000)
-    return `${Math.floor(num / 1_000_000)} million ${Math.floor(
-      (num % 1_000_000) / 1_000
-    )} thousand...`;
-  if (num >= 1_000)
-    return `${Math.floor(num / 1_000)} thousand ${
-      num % 1_000 > 0 ? `${num % 1_000} VND...` : ""
-    }`;
-  return `${num} VND`;
+  const raw = numStr.replace(/,/g, "");
+  const num = Number.parseInt(raw, 10);
+  if (!Number.isFinite(num) || num === 0) {
+    return "";
+  }
+
+  const formatter = new Intl.NumberFormat("vi-VN");
+  const units = [
+    { value: 1_000_000_000, label: "tỷ" },
+    { value: 1_000_000, label: "triệu" },
+    { value: 1_000, label: "nghìn" },
+  ];
+
+  const segments: string[] = [];
+  let remaining = num;
+
+  units.forEach(({ value, label }) => {
+    if (remaining >= value) {
+      const count = Math.floor(remaining / value);
+      segments.push(`${formatter.format(count)} ${label}`);
+      remaining %= value;
+    }
+  });
+
+  if (segments.length === 0) {
+    return `${formatter.format(num)} đồng`;
+  }
+
+  if (remaining > 0) {
+    segments.push(`${formatter.format(remaining)} đồng`);
+  } else {
+    const lastIndex = segments.length - 1;
+    segments[lastIndex] = `${segments[lastIndex]} đồng`;
+  }
+
+  return segments.join(" ");
 };
 
 // --- Props ---

--- a/src/components/forms/CustomSelect.tsx
+++ b/src/components/forms/CustomSelect.tsx
@@ -22,6 +22,12 @@ const SearchIcon = () => <svg className="h-5 w-5 text-gray-400" xmlns="http://ww
 
 const ADD_NEW_VALUE = "__add_new__";
 
+const normalizeText = (value: string) =>
+  value
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .toLowerCase();
+
 export default function CustomSelect({ label, value, onChange, options, required = false, defaultTab, onAddNew, addNewLabel }: CustomSelectProps) {
   const t = createTranslator();
   const [query, setQuery] = useState('');
@@ -57,7 +63,10 @@ export default function CustomSelect({ label, value, onChange, options, required
   const filteredOptions = useMemo(() => {
     let filtered = options;
     if (activeTab !== 'All') { filtered = filtered.filter(opt => opt.type === activeTab); }
-    if (query !== '') { filtered = filtered.filter(opt => opt.name.toLowerCase().includes(query.toLowerCase())); }
+    const normalizedQuery = normalizeText(query);
+    if (normalizedQuery !== '') {
+      filtered = filtered.filter((opt) => normalizeText(opt.name).includes(normalizedQuery));
+    }
     return filtered;
   }, [query, options, activeTab]);
 

--- a/src/components/ui/ConfirmDialog.tsx
+++ b/src/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useEffect } from "react";
+
+type ConfirmDialogProps = {
+  open: boolean;
+  title: string;
+  description?: string;
+  confirmLabel: string;
+  cancelLabel: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+export default function ConfirmDialog({
+  open,
+  title,
+  description,
+  confirmLabel,
+  cancelLabel,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onCancel();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [open, onCancel]);
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-gray-900/40 px-4 py-6 backdrop-blur-sm"
+    >
+      <div className="w-full max-w-md rounded-xl border border-gray-200 bg-white p-6 shadow-2xl">
+        <div className="mb-4 flex items-center gap-3">
+          <span className="flex h-10 w-10 items-center justify-center rounded-full bg-amber-100 text-amber-600">
+            <svg
+              aria-hidden="true"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={1.5}
+              className="h-6 w-6"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M12 9v4m0 4h.01M3.5 19h17l-8.5-14-8.5 14z"
+              />
+            </svg>
+          </span>
+          <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
+        </div>
+
+        {description ? <p className="mb-6 text-sm leading-relaxed text-gray-600">{description}</p> : null}
+
+        <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="inline-flex items-center justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-100"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className="inline-flex items-center justify-center rounded-md border border-transparent bg-amber-500 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-amber-600"
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -46,6 +46,7 @@ type MockSubcategory = {
   image_url: string | null;
   transaction_nature: "EX" | "IN" | "TF" | "DE";
   categories: { name: string; transaction_nature: "EX" | "IN" | "TF" | "DE" }[];
+  is_shop?: boolean;
 };
 
 type MockPerson = {
@@ -199,6 +200,7 @@ const mockSubcategories: MockSubcategory[] = [
     image_url: null,
     transaction_nature: "EX",
     categories: [{ name: "Groceries", transaction_nature: "EX" }],
+    is_shop: true,
   },
   {
     id: "sub-salary",
@@ -206,6 +208,7 @@ const mockSubcategories: MockSubcategory[] = [
     image_url: null,
     transaction_nature: "IN",
     categories: [{ name: "Income", transaction_nature: "IN" }],
+    is_shop: false,
   },
   {
     id: "sub-investments",
@@ -213,6 +216,7 @@ const mockSubcategories: MockSubcategory[] = [
     image_url: null,
     transaction_nature: "TF",
     categories: [{ name: "Transfers", transaction_nature: "TF" }],
+    is_shop: false,
   },
   {
     id: "sub-rent",
@@ -220,6 +224,7 @@ const mockSubcategories: MockSubcategory[] = [
     image_url: null,
     transaction_nature: "EX",
     categories: [{ name: "Housing", transaction_nature: "EX" }],
+    is_shop: false,
   },
   {
     id: "sub-coffee",
@@ -227,6 +232,7 @@ const mockSubcategories: MockSubcategory[] = [
     image_url: null,
     transaction_nature: "EX",
     categories: [{ name: "Dining", transaction_nature: "EX" }],
+    is_shop: true,
   },
   {
     id: "sub-freelance",
@@ -234,6 +240,7 @@ const mockSubcategories: MockSubcategory[] = [
     image_url: null,
     transaction_nature: "IN",
     categories: [{ name: "Income", transaction_nature: "IN" }],
+    is_shop: false,
   },
 ];
 

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -5,11 +5,12 @@ export const DEFAULT_LOCALE: Locale = "en";
 const resources = {
   en: {
     common: {
-      appName: "Gemini Money",
+      appName: "Money Flow",
       addNew: "Add New",
       add: "Add",
       cancel: "Cancel",
       save: "Save",
+      confirm: "Confirm",
       back: "Back",
       loading: "Saving...",
       loadingApp: "Loading...",
@@ -124,6 +125,9 @@ const resources = {
       addButton: "+ Add Person",
       addMockTooltip: "Add person (coming soon)",
       addMockAlert: "Person creation will be available soon.",
+      filters: {
+        peopleList: "People list",
+      },
       views: {
         list: "List view",
         cards: "Card view",
@@ -176,18 +180,32 @@ const resources = {
       },
       addAccount: "Add Account",
       addAccountPlaceholder: "Account creation is coming soon.",
+      addShop: "Add Shop",
+      addShopPlaceholder: "Shop creation is coming soon.",
       addCategory: {
         expense: "Add Expense Category",
         income: "Add Income Category",
         transfer: "Add Transfer Category",
         debt: "Add Debt Category",
       },
+      confirmLeaveTitle: "Leave this form?",
       confirmLeave: "Are you sure you want to go back? Unsaved changes will be lost.",
       hints: {
         transferSameAccount: "Avoid choosing the same account for both sides of a transfer.",
       },
       errors: {
         sameTransferAccount: "You cannot transfer between the same account.",
+      },
+      shop: {
+        sectionTitle: "Shop & bank details",
+        helper: "Connect a shop to keep track of where this transaction happens.",
+        tabs: {
+          shop: "Shop",
+          bank: "Bank",
+        },
+        shopLabel: "Shop",
+        addShop: "Add shop",
+        bankComingSoon: "Linking bank information for shops will be available soon.",
       },
     },
     amountInput: {
@@ -248,11 +266,12 @@ const resources = {
   },
   vi: {
     common: {
-      appName: "Gemini Money",
+      appName: "Money Flow",
       addNew: "Thêm mới",
       add: "Thêm",
       cancel: "Hủy",
       save: "Lưu",
+      confirm: "Xác nhận",
       back: "Quay lại",
       loading: "Đang lưu...",
       loadingApp: "Đang tải...",
@@ -367,6 +386,9 @@ const resources = {
       addButton: "+ Thêm người",
       addMockTooltip: "Thêm người (sắp ra mắt)",
       addMockAlert: "Tính năng thêm người sẽ sớm có mặt.",
+      filters: {
+        peopleList: "Danh sách người",
+      },
       views: {
         list: "Dạng danh sách",
         cards: "Dạng thẻ",
@@ -419,18 +441,32 @@ const resources = {
       },
       addAccount: "Thêm tài khoản",
       addAccountPlaceholder: "Tính năng thêm tài khoản sẽ sớm có mặt.",
+      addShop: "Thêm cửa hàng",
+      addShopPlaceholder: "Tính năng tạo cửa hàng sẽ sớm ra mắt.",
       addCategory: {
         expense: "Thêm danh mục Chi tiêu",
         income: "Thêm danh mục Thu nhập",
         transfer: "Thêm danh mục Chuyển khoản",
         debt: "Thêm danh mục Công nợ",
       },
+      confirmLeaveTitle: "Thoát khỏi biểu mẫu?",
       confirmLeave: "Bạn có chắc muốn quay lại? Thông tin chưa lưu sẽ bị mất.",
       hints: {
         transferSameAccount: "Hãy tránh chọn cùng một tài khoản cho hai chiều chuyển khoản.",
       },
       errors: {
         sameTransferAccount: "Không thể chuyển khoản trong cùng một tài khoản.",
+      },
+      shop: {
+        sectionTitle: "Thông tin cửa hàng & ngân hàng",
+        helper: "Liên kết cửa hàng để quản lý giao dịch chính xác hơn.",
+        tabs: {
+          shop: "Cửa hàng",
+          bank: "Ngân hàng",
+        },
+        shopLabel: "Chọn cửa hàng",
+        addShop: "Thêm cửa hàng",
+        bankComingSoon: "Tính năng liên kết tài khoản ngân hàng sẽ sớm có mặt.",
       },
     },
     amountInput: {


### PR DESCRIPTION
## Summary
- replace the People account filter with a searchable people list and move reset warnings to an in-app dialog
- add a reusable confirmation dialog, Vietnamese amount text, and refresh the branding to "Money Flow"
- extend the add transaction form with shop selection tabs, mock shop data, and persist the new shop_id field

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5dc410a708329a2d73477f4913a5c