### PR TITLE
Refine search clear buttons and harden category creation

### DIFF
--- a/src/app/categories/CategoriesView.tsx
+++ b/src/app/categories/CategoriesView.tsx
@@ -9,6 +9,7 @@ import RemoteImage from "@/components/RemoteImage";
 import { useAppShell } from "@/components/AppShellProvider";
 import { createTranslator } from "@/lib/i18n";
 import { normalizeTransactionNature } from "@/lib/transactionNature";
+import { ClearIcon } from "@/components/Icons";
 
 import type { CategoryRecord } from "./page";
 import { deleteCategory } from "./actions";
@@ -269,14 +270,18 @@ export default function CategoriesView({ categories, errorMessage }: CategoriesV
                   className="w-full rounded-md border border-gray-300 px-3 py-2 pr-24 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
                 />
                 {searchTerm ? (
-                  <button
-                    type="button"
-                    onClick={handleSearchClear}
-                    className="absolute inset-y-1.5 right-2 inline-flex items-center rounded-md border border-transparent px-2 text-xs font-semibold uppercase tracking-wide text-indigo-600 transition hover:border-indigo-100 hover:bg-indigo-50"
-                    aria-label={t("common.clear")}
-                  >
-                    {t("common.clear")}
-                  </button>
+                  <div className="absolute inset-y-1.5 right-2 flex items-center">
+                    <Tooltip label={t("common.clear")}>
+                      <button
+                        type="button"
+                        onClick={handleSearchClear}
+                        className="inline-flex items-center justify-center rounded-md border border-transparent p-2 text-indigo-600 transition hover:border-indigo-100 hover:bg-indigo-50"
+                        aria-label={t("common.clear")}
+                      >
+                        <ClearIcon />
+                      </button>
+                    </Tooltip>
+                  </div>
                 ) : null}
               </div>
             </div>

--- a/src/app/people/PeopleView.tsx
+++ b/src/app/people/PeopleView.tsx
@@ -6,6 +6,7 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
 import CustomSelect from "@/components/forms/CustomSelect";
 import Tooltip from "@/components/Tooltip";
+import { ClearIcon } from "@/components/Icons";
 import RemoteImage from "@/components/RemoteImage";
 import ConfirmDialog from "@/components/ui/ConfirmDialog";
 import { createTranslator } from "@/lib/i18n";
@@ -435,14 +436,18 @@ export default function PeopleView({ people, filters, errorMessage }: PeopleView
                   className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 pr-24 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
                 />
                 {searchValue ? (
-                  <button
-                    type="button"
-                    onClick={handleSearchClear}
-                    className="absolute inset-y-1.5 right-2 inline-flex items-center rounded-md border border-transparent px-2 text-xs font-semibold uppercase tracking-wide text-indigo-600 transition hover:border-indigo-100 hover:bg-indigo-50"
-                    aria-label={t("common.clear")}
-                  >
-                    {t("common.clear")}
-                  </button>
+                  <div className="absolute inset-y-1.5 right-2 flex items-center">
+                    <Tooltip label={t("common.clear")}>
+                      <button
+                        type="button"
+                        onClick={handleSearchClear}
+                        className="inline-flex items-center justify-center rounded-md border border-transparent p-2 text-indigo-600 transition hover:border-indigo-100 hover:bg-indigo-50"
+                        aria-label={t("common.clear")}
+                      >
+                        <ClearIcon />
+                      </button>
+                    </Tooltip>
+                  </div>
                 ) : null}
               </div>
             </div>

--- a/src/app/transactions/TransactionsView.tsx
+++ b/src/app/transactions/TransactionsView.tsx
@@ -10,6 +10,7 @@ import Tooltip from "@/components/Tooltip";
 import RemoteImage from "@/components/RemoteImage";
 import { createTranslator } from "@/lib/i18n";
 import { numberToVietnameseWords } from "@/lib/numberToVietnameseWords";
+import { ClearIcon } from "@/components/Icons";
 import { deleteTransaction, deleteTransactions } from "./actions";
 import { DEFAULT_PAGE_SIZE, PAGE_SIZE_OPTIONS } from "./constants";
 import TransactionForm from "./add/TransactionForm";
@@ -1193,14 +1194,18 @@ export default function TransactionsView({
                     className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 pr-24 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
                   />
                   {searchValue ? (
-                    <button
-                      type="button"
-                      onClick={handleSearchClear}
-                      className="absolute inset-y-1.5 right-2 inline-flex items-center rounded-md border border-transparent px-2 text-xs font-semibold uppercase tracking-wide text-indigo-600 transition hover:border-indigo-100 hover:bg-indigo-50"
-                      aria-label={t("common.clear")}
-                    >
-                      {t("common.clear")}
-                    </button>
+                    <div className="absolute inset-y-1.5 right-2 flex items-center">
+                      <Tooltip label={t("common.clear")}>
+                        <button
+                          type="button"
+                          onClick={handleSearchClear}
+                          className="inline-flex items-center justify-center rounded-md border border-transparent p-2 text-indigo-600 transition hover:border-indigo-100 hover:bg-indigo-50"
+                          aria-label={t("common.clear")}
+                        >
+                          <ClearIcon />
+                        </button>
+                      </Tooltip>
+                    </div>
                   ) : null}
                 </div>
               </div>

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -11,3 +11,19 @@ export const ExpenseIcon = () => (
 export const BalanceIcon = () => (
   <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 6l3 1m0 0l-3 9a5.002 5.002 0 006.001 0M6 7l3 9M6 7l6-2m6 2l3-1m-3 1l-3 9a5.002 5.002 0 006.001 0M18 7l3 9m-3-9l-6-2m0-2v2m0 16V5m0 16H9m3 0h3" /></svg>
 );
+
+export const ClearIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 20 20"
+    fill="currentColor"
+    className="h-4 w-4"
+    aria-hidden="true"
+  >
+    <path
+      fillRule="evenodd"
+      d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+      clipRule="evenodd"
+    />
+  </svg>
+);

--- a/src/components/forms/CustomSelect.tsx
+++ b/src/components/forms/CustomSelect.tsx
@@ -4,6 +4,8 @@ import { Listbox, Transition } from '@headlessui/react';
 import { Fragment, useState, useMemo, useEffect, useRef } from 'react';
 import { createTranslator } from '@/lib/i18n';
 import RemoteImage from '@/components/RemoteImage';
+import Tooltip from '@/components/Tooltip';
+import { ClearIcon } from '@/components/Icons';
 
 export type Option = { id: string; name: string; imageUrl?: string; type?: string; };
 type CustomSelectProps = {
@@ -133,17 +135,21 @@ export default function CustomSelect({ label, value, onChange, options, required
                     onChange={(e) => setQuery(e.target.value)}
                   />
                   {query ? (
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setQuery("");
-                        searchInputRef.current?.focus();
-                      }}
-                      className="absolute inset-y-1 right-2 inline-flex items-center rounded-md border border-transparent px-2 text-xs font-semibold uppercase tracking-wide text-indigo-600 transition hover:border-indigo-100 hover:bg-indigo-50"
-                      aria-label={t("common.clear")}
-                    >
-                      {t("common.clear")}
-                    </button>
+                    <div className="absolute inset-y-1 right-2 flex items-center">
+                      <Tooltip label={t("common.clear")}>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setQuery("");
+                            searchInputRef.current?.focus();
+                          }}
+                          className="inline-flex items-center justify-center rounded-md border border-transparent p-2 text-indigo-600 transition hover:border-indigo-100 hover:bg-indigo-50"
+                          aria-label={t("common.clear")}
+                        >
+                          <ClearIcon />
+                        </button>
+                      </Tooltip>
+                    </div>
                   ) : null}
                 </div>
 

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -48,7 +48,7 @@ const resources = {
     },
     transactions: {
       title: "Transaction History",
-      addButton: "+ Add New",
+      addButton: "Add New",
       tableHeaders: {
         select: "Select",
         date: "Date",
@@ -309,7 +309,7 @@ const resources = {
     },
     transactions: {
       title: "Lịch sử Giao dịch",
-      addButton: "+ Thêm mới",
+      addButton: "Thêm mới",
       tableHeaders: {
         select: "Chọn",
         date: "Ngày",

--- a/src/lib/transactionNature.ts
+++ b/src/lib/transactionNature.ts
@@ -21,10 +21,10 @@ const aliasMap: Record<string, TransactionNatureCode> = {
 };
 
 const databaseNatureMap: Record<TransactionNatureCode, string[]> = {
-  EX: ["EX", "Expense", "Expenses"],
-  IN: ["IN", "Income", "Incomes"],
-  TF: ["TF", "Transfer", "Transfers"],
-  DE: ["DE", "Debt", "Debts"],
+  EX: ["Expense", "Expenses", "EX"],
+  IN: ["Income", "Incomes", "IN"],
+  TF: ["Transfer", "Transfers", "TF"],
+  DE: ["Debt", "Debts", "DE"],
 };
 
 export function normalizeTransactionNature(
@@ -48,7 +48,24 @@ export function getDatabaseNatureCandidates(
   nature: TransactionNatureCode
 ): string[] {
   const candidates = databaseNatureMap[nature] ?? [nature];
-  return Array.from(new Set(candidates.map((candidate) => candidate.trim()))).filter(Boolean);
+  const seen = new Set<string>();
+  const addCandidate = (value: string) => {
+    const trimmed = value.trim();
+    if (!trimmed || seen.has(trimmed)) {
+      return;
+    }
+    seen.add(trimmed);
+  };
+
+  candidates.forEach((candidate) => {
+    addCandidate(candidate);
+    addCandidate(candidate.toUpperCase());
+    addCandidate(candidate.toLowerCase());
+  });
+
+  addCandidate(nature);
+
+  return Array.from(seen);
 }
 
 export function includesTransferNature(value?: string | null): boolean {


### PR DESCRIPTION
## Summary
- swap text-based clear buttons in search inputs for icon-only actions with tooltips and reuse a shared clear icon
- remove the leading plus sign from the category add button copy in both locales
- expand transaction nature candidates so Supabase category inserts comply with database constraints when triggered from the add-transaction flow

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6021fcc5083298ca49bd4ea02ed44