### PR TITLE
Align transaction nature types in form data

### DIFF
--- a/src/app/transactions/add/formData.ts
+++ b/src/app/transactions/add/formData.ts
@@ -1,6 +1,9 @@
 import { supabase, isSupabaseConfigured, supabaseConfigurationError } from "@/lib/supabaseClient";
 import { getMockTransactionFormData } from "@/data/mockData";
-import { normalizeTransactionNature } from "@/lib/transactionNature";
+import {
+  normalizeTransactionNature,
+  type TransactionNatureCode,
+} from "@/lib/transactionNature";
 
 export type Account = {
   id: string;
@@ -14,7 +17,7 @@ export type Account = {
 
 type CategoryInfo = {
   name: string;
-  transaction_nature: string | null;
+  transaction_nature: TransactionNatureCode | null;
 };
 
 type CategoryRelation = {
@@ -72,7 +75,7 @@ export type Subcategory = {
   id: string;
   name: string;
   image_url: string | null;
-  transaction_nature?: string | null;
+  transaction_nature?: TransactionNatureCode | null;
   categories: CategoryInfo[] | CategoryInfo | null;
   is_shop?: boolean | null;
 };


### PR DESCRIPTION
## Summary
- align category and subcategory transaction nature typing with the normalized transaction nature codes
- ensure form data utilities import the transaction nature type to avoid mismatches during filtering

## Testing
- npm run build *(fails: Turbopack cannot fetch Inter font without network access)*

------
https://chatgpt.com/codex/tasks/task_e_68d65aaf678c8329a3e724a3649e7a6e