### PR TITLE
Fix cashback reset type error

### DIFF
--- a/src/components/forms/CashbackInput.tsx
+++ b/src/components/forms/CashbackInput.tsx
@@ -198,7 +198,7 @@ export default function CashbackInput({ transactionAmount, account, onCashbackCh
           setLastEdited("amount");
         } else {
           setLastEdited(null);
-          onCashbackChange({ percent: 0, amount: 0 });
+          onCashbackChange({ percent: 0, amount: 0, source: null });
         }
       }
       return;
@@ -218,7 +218,7 @@ export default function CashbackInput({ transactionAmount, account, onCashbackCh
           setLastEdited("percent");
         } else {
           setLastEdited(null);
-          onCashbackChange({ percent: 0, amount: 0 });
+          onCashbackChange({ percent: 0, amount: 0, source: null });
         }
       }
       return;


### PR DESCRIPTION
## Summary
- include the `source` field when resetting cashback changes to satisfy the component contract

## Testing
- npm run build *(fails: next/font cannot download Inter from Google Fonts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d66225cfb08329b53351b24469a927