### PR TITLE
Add missing shop add-new translation keys

### DIFF
--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -160,6 +160,9 @@ const resources = {
         typeLabel: "Type",
         allTypes: "All types",
       },
+      actions: {
+        addNew: "Add new shop",
+      },
       fields: {
         type: "Category",
         created: "Created",
@@ -443,6 +446,9 @@ const resources = {
         searchPlaceholder: "Tìm kiếm cửa hàng...",
         typeLabel: "Loại",
         allTypes: "Tất cả",
+      },
+      actions: {
+        addNew: "Thêm cửa hàng mới",
       },
       fields: {
         type: "Phân loại",


### PR DESCRIPTION
## Summary
- add the missing translation key for the "add new shop" action in English
- provide the corresponding Vietnamese translation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6c2674dc483298a0659cd09a45668